### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "paper-slider": "polymerelements/paper-slider#^1.0.0",
     "paper-styles": "polymerelements/paper-styles#^1.0.0",
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,8 +15,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../iron-page-url.html">
   <link rel="import" href="../iron-query-params.html">
-  <link rel="import" href="../../paper-styles/classes/typography.html">
-  <link rel="import" href="../../iron-flex-layout/classes/iron-flex-layout.html">
+  <link rel="import" href="../../paper-styles/typography.html">
+  <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
   <link rel="import" href="../../paper-input/paper-input.html">
   <link rel="import" href="../../paper-slider/paper-slider.html">
   <link rel="import" href="../../paper-button/paper-button.html">
@@ -24,7 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
 
-  <dom-module id='iron-page-url-demo'>
+  <dom-module id="iron-page-url-demo">
     <template>
       <style>
         div.inputs {
@@ -34,49 +34,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           display: inline-block;
           width: 100px;
         }
-        span.seconds {
-        }
-        [layout] {
-          @apply(--layout);
-        }
-        [layout][horizontal] {
-          @apply(--layout-horizontal);
-        }
-        [layout][horizontal] > div {
-          padding: 20px;
-          max-width: 500px;
-        }
-        [layout][vertical] {
-          @apply(--layout-vertical);
-        }
-        [layout][flex] {
-          @apply(--layout-flex);
-        }
+
         h3 {
           padding: 0;
           margin: 0;
         }
+
+        .inputs, .history_entries {
+          @apply(--layout-vertical);
+          @apply(--layout-flex);
+          padding: 20px;
+          max-width: 500px;
+        }
+
+        .container {
+          @apply(--layout-horizontal);
+        }
+
       </style>
-      <iron-page-url path='{{path}}' hash='{{hash}}' query='{{query}}'
-                     dwell-time='{{dwellTime}}'>
+      <iron-page-url path="{{path}}" hash="{{hash}}" query="{{query}}"
+                     dwell-time="{{dwellTime}}">
       </iron-page-url>
-      <iron-query-params params-string='{{query}}' params-object='{{params}}'>
+      <iron-query-params params-string="{{query}}" params-object="{{params}}">
       </iron-query-params>
 
-      <div layout horizontal>
-        <div layout vertical flex class='inputs'>
+      <div class="container">
+        <div class="inputs">
           <h3>URL</h3>
-          <paper-input label='path' value='{{path}}' always-float-label>
+          <paper-input label="path" value="{{path}}" always-float-label>
           </paper-input>
-          <paper-input label='hash' value='{{hash}}' always-float-label>
+          <paper-input label="hash" value="{{hash}}" always-float-label>
           </paper-input>
-          <paper-input label='params' value='{{paramsString}}'
-                       invalid='{{paramsInvalid}}'
-                       error-message='Should be legal JSON'
+          <paper-input label="params" value="{{paramsString}}"
+                       invalid="{{paramsInvalid}}"
+                       error-message="Should be legal JSON"
                        always-float-label>
           </paper-input>
         </div>
-        <div layout vertical flex class='history_entries'>
+        <div class="history_entries">
           <h3>Dwell Time</h3>
           <p>
             iron-page-url won't add extraneous entries to the browser's history when changes come in rapid fire.
@@ -91,14 +86,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <label>Dwell time:</label>
             {{inSeconds(dwellTime)}}s
           </div>
-          <paper-slider min="-1" max="5000" value='2000' step='100'
-                        immediate-value='{{dwellTime}}'>
+          <paper-slider min="-1" max="5000" value="2000" step="100"
+                        immediate-value="{{dwellTime}}">
           </paper-slider>
         </div>
       </div>
-      <div layout horizontal flex>
-        <a href='#lolol'><paper-button raised>#lolol</paper-button></a>
-        <a href='?hi=there&some=none#wat_for'><div>{"hi": "there", "some": "none"}, #wat_for</div></a>
+      <div class="container">
+        <a href="#lolol😹"><paper-button raised>#lolol😹</paper-button></a>
+        <a href="?hi=there&some=none#wat_for"><div>{"hi": "there", "some": "none"}, #wat_for</div></a>
       </div>
     </template>
     <script>

--- a/demo/iron-query-params.html
+++ b/demo/iron-query-params.html
@@ -14,14 +14,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../iron-query-params.html">
-  <link rel="import" href="../../paper-styles/classes/typography.html">
-  <link rel="import" href="../../iron-flex-layout/classes/iron-flex-layout.html">
+  <link rel="import" href="../../paper-styles/typography.html">
+  <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
   <link rel="import" href="../../paper-input/paper-input.html">
   <link rel="stylesheet" href="../../paper-styles/demo.css">
 </head>
 <body>
 
-  <dom-module id='iron-query-params-demo'>
+  <dom-module id="iron-query-params-demo">
     <template>
       <style>
         div.inputs {
@@ -31,41 +31,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           display: inline-block;
           width: 100px;
         }
-        span.seconds {
-        }
-        [layout] {
-          @apply(--layout);
-        }
-        [layout][horizontal] {
-          @apply(--layout-horizontal);
-        }
-        [layout][horizontal] > div {
-          padding: 20px;
-          max-width: 500px;
-        }
-        [layout][vertical] {
-          @apply(--layout-vertical);
-        }
-        [layout][flex] {
-          @apply(--layout-flex);
-        }
+
         h3 {
           padding: 0;
           margin: 0;
         }
+
+        .inputs {
+          @apply(--layout-vertical);
+          @apply(--layout-flex);
+          padding: 20px;
+          max-width: 500px;
+        }
+
+        .container {
+          @apply(--layout-horizontal);
+        }
       </style>
       <iron-query-params
-          params-string='{{paramString}}' params-object='{{params}}'>
+          params-string="{{paramString}}" params-object="{{params}}">
       </iron-query-params>
 
-      <div layout horizontal>
-        <div layout vertical flex class='inputs'>
-          <paper-input label='params as string'
-                       value='{{paramString}}' always-float-label>
+      <div class="container">
+        <div class="inputs">
+          <paper-input label="params as string"
+                       value="{{paramString}}" always-float-label>
           </paper-input>
-          <paper-input label='params as object' value='{{paramsString}}'
-                       invalid='{{paramsInvalid}}'
-                       error-message='Should be legal JSON'
+          <paper-input label="params as object" value="{{paramsString}}"
+                       invalid="{{paramsInvalid}}"
+                       error-message="Should be legal JSON"
                        always-float-label>
           </paper-input>
         </div>

--- a/test/iron-page-url.html
+++ b/test/iron-page-url.html
@@ -13,11 +13,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
   <link rel="import" href="../../polymer/polymer.html">
   <link rel="import" href="../../promise-polyfill/promise-polyfill.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../iron-page-url.html">
 </head>
 <body>

--- a/test/iron-query-params.html
+++ b/test/iron-query-params.html
@@ -13,11 +13,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
   <link rel="import" href="../../polymer/polymer.html">
   <link rel="import" href="../../promise-polyfill/promise-polyfill.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../iron-query-params.html">
 </head>
 <body>


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way.

This was a bit of a bigger change, because the demo was a bit weird. Also, I changed Peter's single quotes in HTML with high prejudice.

/cc @rictic 
