### PR TITLE
Support and test redirecting.

### DIFF
--- a/iron-location.html
+++ b/iron-location.html
@@ -147,8 +147,8 @@ milliseconds.
       this.listen(window, 'popstate', '_urlChanged');
       this.listen(/** @type {!HTMLBodyElement} */(document.body), 'click', '_globalOnClick');
 
-      this._urlChanged();
       this._initialized = true;
+      this._urlChanged();
     },
     detached: function() {
       this.unlisten(window, 'hashchange', '_hashChanged');

--- a/test/iron-location.html
+++ b/test/iron-location.html
@@ -18,6 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../polymer/polymer.html">
   <link rel="import" href="../../promise-polyfill/promise-polyfill.html">
   <link rel="import" href="../iron-location.html">
+  <link rel="import" href="./redirection.html">
 </head>
 <body>
 <test-fixture id='Solo'>
@@ -33,7 +34,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </div>
   </template>
 </test-fixture>
-
+<test-fixture id='RedirectHash'>
+  <template>
+    <redirect-hash></redirect-hash>
+  </template>
+</test-fixture>
+<test-fixture id='RedirectPath'>
+  <template>
+    <redirect-path></redirect-path>
+  </template>
+</test-fixture>
+<test-fixture id='RedirectQuery'>
+  <template>
+    <redirect-query></redirect-query>
+  </template>
+</test-fixture>
 
 <script>
   'use strict';
@@ -134,6 +149,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assertHaveSameUrls(urlElem, otherUrlElem);
       });
     });
+    suite('supports doing synchronous redirection', function() {
+      test('of the hash portion of the URL', function() {
+        expect(window.location.hash).to.be.equal('');
+        var redirector = fixture('RedirectHash');
+        expect(window.location.hash).to.be.equal('#redirectedTo');
+        expect(redirector.hash).to.be.equal('redirectedTo');
+        redirector.hash = 'newHash';
+        expect(window.location.hash).to.be.equal('#redirectedTo');
+        expect(redirector.hash).to.be.equal('redirectedTo');
+      });
+
+      test('of the path portion of the URL', function() {
+        expect(window.location.pathname).to.not.be.equal('/redirectedTo');
+        var redirector = fixture('RedirectPath');
+        expect(window.location.pathname).to.be.equal('/redirectedTo');
+        expect(redirector.path).to.be.equal('/redirectedTo');
+        redirector.path = 'newPath';
+        expect(window.location.pathname).to.be.equal('/redirectedTo');
+        expect(redirector.path).to.be.equal('/redirectedTo');
+      });
+
+      test('of the query portion of the URL', function() {
+        expect(window.location.search).to.be.equal('');
+        var redirector = fixture('RedirectQuery');
+        expect(window.location.search).to.be.equal('?redirectedTo');
+        expect(redirector.query).to.be.equal('redirectedTo');
+        redirector.query = 'newQuery';
+        expect(window.location.search).to.be.equal('?redirectedTo');
+        expect(redirector.query).to.be.equal('redirectedTo');
+      });
+
+    })
   });
 
 </script>

--- a/test/redirection.html
+++ b/test/redirection.html
@@ -1,0 +1,59 @@
+<dom-module id='redirect-hash'>
+  <template>
+    <iron-location hash='{{hash}}'></iron-location>
+  </template>
+  <script>
+    Polymer({
+      is: 'redirect-hash',
+      properties: {
+        hash: {
+          value: '',
+          observer: 'hashChanged'
+        }
+      },
+      hashChanged: function(hash) {
+        this.hash = 'redirectedTo';
+      }
+    });
+  </script>
+</dom-module>
+
+<dom-module id='redirect-path'>
+  <template>
+    <iron-location path='{{path}}'></iron-location>
+  </template>
+  <script>
+    Polymer({
+      is: 'redirect-path',
+      properties: {
+        path: {
+          value: '',
+          observer: 'pathChanged'
+        }
+      },
+      pathChanged: function(path) {
+        this.path = '/redirectedTo';
+      }
+    });
+  </script>
+</dom-module>
+
+<dom-module id='redirect-query'>
+  <template>
+    <iron-location query='{{query}}'></iron-location>
+  </template>
+  <script>
+    Polymer({
+      is: 'redirect-query',
+      properties: {
+        query: {
+          value: '',
+          observer: 'queryChanged'
+        }
+      },
+      queryChanged: function(query) {
+        this.query = 'redirectedTo';
+      }
+    });
+  </script>
+</dom-module>


### PR DESCRIPTION
Notably, iron-location should now support a redirection happening immediately
after it wakes up and reads the values from the URL.

We still do not support writing to an iron-location's properties before it has
read from the URL (e.g. in ready() or attached() of other elements). This is
intentional, as it's almost always a mistake to redirect without first
examining the URL of the initial page load, as that's a major signal of user
intent.