### PR TITLE
Add tests for link interception.

### DIFF
--- a/iron-location.html
+++ b/iron-location.html
@@ -243,10 +243,6 @@ milliseconds.
      * is clicking on, if we can and should override the resulting full
      * page navigation. Returns null otherwise.
      *
-     * This method is separated away from _globalOnClick for testability,
-     * as we can't test that a clicked link should have resulted in navigating
-     * away from the test page.
-     *
      * @param {MouseEvent} event .
      * @return {string?} .
      */
@@ -261,18 +257,32 @@ milliseconds.
         return null;
       }
       var eventPath = Polymer.dom(event).path;
-      var href = null;
+      var anchor = null;
       for (var i = 0; i < eventPath.length; i++) {
         var element = eventPath[i];
         if (element.tagName === 'A' && element.href) {
-          href = element.href;
+          anchor = element;
           break;
         }
       }
+
       // If there's no link there's nothing to do.
-      if (!href) {
-        return null;
+      if (!anchor) {
+        return;
       }
+
+      // Target blank is a new tab, don't intercept.
+      if (anchor.target === '_blank') {
+        return;
+      }
+      // If the link is for an existing parent frame, don't intercept.
+      if ((anchor.target === '_top' ||
+           anchor.target === '_parent') &&
+          window.top !== window) {
+        return;
+      }
+
+      var href = anchor.href;
 
       // It only makes sense for us to intercept same-origin navigations.
       // pushState/replaceState don't work with cross-origin links.

--- a/test/iron-location.html
+++ b/test/iron-location.html
@@ -61,10 +61,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
   }
 
+  function makeAbsoluteUrl(path) {
+    return window.location.protocol + '//' + window.location.host + path;
+  }
+
   // A window.history.replaceState wrapper that's smart about baseURI.
-  function replaceState(url) {
-    window.history.replaceState(
-        {}, '', window.location.protocol + '//' + window.location.host + url);
+  function replaceState(path) {
+    window.history.replaceState({}, '', makeAbsoluteUrl(path));
   }
 
   /**
@@ -163,6 +166,77 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         urlElem.hash = 'lkjljifosjkldfjlksjfldsjf';
         assertHaveSameUrls(urlElem, otherUrlElem);
       });
+    });
+    suite('when intercepting links', function() {
+
+      /**
+       * Clicks the given link while an iron-location element with the given
+       * urlSpaceRegex is in the same document. Returns whether the
+       * iron-location prevented the default behavior of the click.
+       *
+       * No matter what, it prevents the default behavior of the click itself
+       * to ensure that no navigation occurs (as that would interrupt
+       * running and reporting these tests!)
+       */
+      function isClickCaptured(anchor, urlSpaceRegex) {
+        var defaultWasPrevented;
+        function handler(event) {
+          expect(event.target).to.be.eq(anchor);
+          defaultWasPrevented = event.defaultPrevented;
+          event.preventDefault();
+          expect(event.defaultPrevented).to.be.eq(true);
+        }
+        window.addEventListener('click', handler);
+        var ironLocation = fixture('Solo');
+        if (urlSpaceRegex != null) {
+          ironLocation.urlSpaceRegex = urlSpaceRegex;
+        }
+        document.body.appendChild(anchor);
+        anchor.click();
+        document.body.removeChild(anchor);
+        window.removeEventListener('click', handler);
+        return defaultWasPrevented;
+      }
+
+      test('simple link to / is intercepted', function() {
+        var anchor = document.createElement('a');
+        if (document.baseURI !== window.location.href) {
+          anchor.href = makeAbsoluteUrl('/');
+        } else {
+          anchor.href = '/';
+        }
+
+        expect(isClickCaptured(anchor)).to.be.eq(true);
+      });
+
+      test('link that matches url space is intercepted', function() {
+        var anchor = document.createElement('a');
+        anchor.href = makeAbsoluteUrl('/foo');
+
+        expect(isClickCaptured(anchor, '/fo+')).to.be.eq(true);
+      });
+
+      test('link that doesn\'t match url space isn\'t intercepted', function() {
+        var anchor = document.createElement('a');
+        anchor.href = makeAbsoluteUrl('/bar');
+
+        expect(isClickCaptured(anchor, '/fo+')).to.be.eq(false);
+      });
+
+      test('link to another domain isn\'t intercepted', function() {
+        var anchor = document.createElement('a');
+        anchor.href = 'http://example.com/';
+
+        expect(isClickCaptured(anchor)).to.be.eq(false);
+      });
+
+      test('a link with target=_blank isn\'t intercepted', function() {
+        var anchor = document.createElement('a');
+        anchor.href = makeAbsoluteUrl('/');
+        anchor.target = '_blank';
+
+        expect(isClickCaptured(anchor)).to.be.eq(false);
+      })
     });
 
     suite('supports doing synchronous redirection', function() {


### PR DESCRIPTION
Moved logic from https://github.com/PolymerElements/carbon-route/pull/95 while splitting it up and ensuring that even when clicks aren't captured there will never be a navigation.

Also added support for the `target` attribute of anchor tags based on the docs at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target

Fixes #15 