### PR TITLE
A couple refinements to anchor click capturing.

### DIFF
--- a/iron-location.html
+++ b/iron-location.html
@@ -274,18 +274,18 @@ milliseconds.
 
       // If there's no link there's nothing to do.
       if (!anchor) {
-        return;
+        return null;
       }
 
       // Target blank is a new tab, don't intercept.
       if (anchor.target === '_blank') {
-        return;
+        return null;
       }
       // If the link is for an existing parent frame, don't intercept.
       if ((anchor.target === '_top' ||
            anchor.target === '_parent') &&
           window.top !== window) {
-        return;
+        return null;
       }
 
       var href = anchor.href;

--- a/iron-location.html
+++ b/iron-location.html
@@ -230,6 +230,12 @@ milliseconds.
      * @param {MouseEvent} event .
      */
     _globalOnClick: function(event) {
+      // If another event handler has stopped this event then there's nothing
+      // for us to do. This can happen e.g. when there are multiple
+      // iron-location elements in a page.
+      if (event.defaultPrevented) {
+        return;
+      }
       var href = this._getSameOriginLinkHref(event);
       if (!href) {
         return;
@@ -319,6 +325,11 @@ milliseconds.
       // Need to use a full URL in case the containing page has a base URI.
       var fullNormalizedHref = new URL(
           normalizedHref, window.location.href).href;
+      // If the navigation is to the current page we shouldn't add a history
+      // entry.
+      if (fullNormalizedHref === window.location.href) {
+        return null;
+      }
       return fullNormalizedHref;
     },
     _makeRegExp: function(urlSpaceRegex) {

--- a/test/iron-location.html
+++ b/test/iron-location.html
@@ -236,6 +236,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         anchor.target = '_blank';
 
         expect(isClickCaptured(anchor)).to.be.eq(false);
+      });
+
+      test('a link with an href to the ' +
+           'current page shouldn\'t add to history.', function() {
+        var anchor = document.createElement('a');
+        anchor.href = window.location.href;
+
+        expect(isClickCaptured(anchor)).to.be.equal(false);
+      });
+
+      test('a click that has already been defaultPrevented ' +
+           'shouldn\'t result in a navigation', function() {
+         fixture('Solo');
+         var anchor = document.createElement('a');
+         anchor.href = makeAbsoluteUrl('/');
+         anchor.addEventListener('click', function(event) {
+           event.preventDefault();
+         });
+         document.body.appendChild(anchor);
+
+         var originalPushState = window.history.pushState;
+         var count = 0;
+         window.history.pushState = function() {
+           count++;
+         }
+         anchor.click();
+         window.history.pushState = originalPushState;
+
+         expect(count).to.be.equal(0);
       })
     });
 


### PR DESCRIPTION
Two changes to further align our behavior with native anchor clicks.

* If something else has prevented the default behavior of a click, we should
  respect that and not perform a navigation.

* If a user clicks a link that points to the exact current page, we shouldn't
  add a history entry.