### PR TITLE
Do not add history entries in the first 200ms.

### DIFF
--- a/iron-location.html
+++ b/iron-location.html
@@ -125,9 +125,8 @@ milliseconds.
         computed: '_makeRegExp(urlSpaceRegex)'
       },
 
-      _lastChangedAtAt: {
-        type: Number,
-        value: -Infinity
+      _lastChangedAt: {
+        type: Number
       },
 
       _initialized: {
@@ -146,6 +145,9 @@ milliseconds.
       this.listen(window, 'location-changed', '_urlChanged');
       this.listen(window, 'popstate', '_urlChanged');
       this.listen(/** @type {!HTMLBodyElement} */(document.body), 'click', '_globalOnClick');
+      // Give a 200ms grace period to make initial redirects without any
+      // additions to the user's history.
+      this._lastChangedAt = window.performance.now() - (this.dwellTime - 200);
 
       this._initialized = true;
       this._urlChanged();
@@ -156,17 +158,6 @@ milliseconds.
       this.unlisten(window, 'popstate', '_urlChanged');
       this.unlisten(/** @type {!HTMLBodyElement} */(document.body), 'click', '_globalOnClick');
       this._initialized = false;
-    },
-    /**
-     * @return {number} the number of milliseconds since some point in the
-     *     past. Only useful for comparing against other results from this
-     *     function.
-     */
-    _now: function() {
-      if (window.performance && window.performance.now) {
-        return window.performance.now();
-      }
-      return new Date().getTime();
     },
     _hashChanged: function() {
       this.hash = window.location.hash.substring(1);
@@ -212,7 +203,7 @@ milliseconds.
       // Need to use a full URL in case the containing page has a base URI.
       var fullNewUrl = new URL(
           newUrl, window.location.protocol + '//' + window.location.host).href;
-      var now = this._now();
+      var now = window.performance.now();
       var shouldReplace =
           this._lastChangedAt + this.dwellTime > now;
       this._lastChangedAt = now;

--- a/test/iron-location.html
+++ b/test/iron-location.html
@@ -141,6 +141,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             '?greeting=hello&target=world&another=key');
       });
     });
+    suite('does not spam the user\'s history', function() {
+      var replaceStateCalls, pushStateCalls;
+      var nativeReplaceState, nativePushState;
+      setup(function() {
+        replaceStateCalls = pushStateCalls = 0;
+        nativeReplaceState = window.history.replaceState;
+        nativePushState = window.history.pushState;
+        window.history.replaceState = function() {
+          replaceStateCalls++;
+        };
+        window.history.pushState = function() {
+          pushStateCalls++;
+        };
+      });
+      teardown(function() {
+        window.history.replaceState = nativeReplaceState;
+        window.history.pushState = nativePushState;
+      });
+      test('when a change happens immediately after ' +
+           'the iron-location is attached', function() {
+        var ironLocation = fixture('Solo');
+        expect(pushStateCalls).to.be.equal(0);
+        expect(replaceStateCalls).to.be.equal(0);
+        ironLocation.path = '/foo';
+        expect(replaceStateCalls).to.be.equal(1);
+        expect(pushStateCalls).to.be.equal(0);
+      });
+    });
     suite('when used with other iron-location elements', function() {
       var otherUrlElem;
       var urlElem;


### PR DESCRIPTION
Fixes #38.

Also, it turns out that all of our supported browsers have
window.performance.now() so we can just call it directly:
http://caniuse.com/#feat=high-resolution-time