### PR TITLE
Support query params containing + instead of %20

### DIFF
--- a/iron-query-params.html
+++ b/iron-query-params.html
@@ -69,7 +69,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
     _decodeParams: function(paramString) {
       var params = {};
-      var paramList = (paramString || '').split('&');
+      
+      // Work around a bug in decodeURIComponent where + is not
+      // converted to spaces:
+      paramString = (paramString || '').replace(/\+/g, '%20');
+
+      var paramList = paramString.split('&');
       for (var i = 0; i < paramList.length; i++) {
         var param = paramList[i].split('=');
         if (param[0]) {

--- a/test/iron-query-params.html
+++ b/test/iron-query-params.html
@@ -63,6 +63,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             object: {'debug': '', 'ok': ''}
           },
           {
+            string: 'plus=turns+into+spaces',
+            object: {'plus': 'turns into spaces'}
+          },
+          {
             string: 'monster%20kid%3A=%F0%9F%98%BF',
             object: {'monster kid:': '😿'}
           },


### PR DESCRIPTION
Internally <iron-query-params> uses decodeUriComponent to decode query string into a javascript object. Turns out upon investigation that decodeUriComponent does not handle all forms of valid encodings, only the ones produced by encodeUriComponent.

Encoding a space into + instead of %20 is relatively common (in query string only, not full urls) and perfectly valid according to https://en.wikipedia.org/wiki/Query_string#URL_encoding

This patch adds a special case around decodeUriComponent so it also handles + in the query string.