### PR TITLE
Query params decode fix

### DIFF
--- a/iron-location.html
+++ b/iron-location.html
@@ -73,7 +73,7 @@ milliseconds.
           type: String,
           notify: true,
           value: function() {
-            return window.decodeURIComponent(window.location.search.slice(1));
+            return window.location.search.slice(1);
           }
         },
         /**
@@ -172,8 +172,7 @@ milliseconds.
         this._dontUpdateUrl = true;
         this._hashChanged();
         this.path = window.decodeURIComponent(window.location.pathname);
-        this.query = window.decodeURIComponent(
-            window.location.search.substring(1));
+        this.query = window.location.search.substring(1);
         this._dontUpdateUrl = false;
         this._updateUrl();
       },
@@ -182,8 +181,7 @@ milliseconds.
             this.path).replace(/\#/g, '%23').replace(/\?/g, '%3F');
         var partiallyEncodedQuery = '';
         if (this.query) {
-          partiallyEncodedQuery = '?' + window.encodeURI(
-              this.query).replace(/\#/g, '%23');
+          partiallyEncodedQuery = '?' + this.query.replace(/\#/g, '%23');
         }
         var partiallyEncodedHash = '';
         if (this.hash) {
@@ -197,8 +195,7 @@ milliseconds.
           return;
         }
         if (this.path === window.decodeURIComponent(window.location.pathname) &&
-            this.query === window.decodeURIComponent(
-                window.location.search.substring(1)) &&
+            this.query === window.location.search.substring(1) &&
             this.hash === window.decodeURIComponent(
                 window.location.hash.substring(1))) {
           // Nothing to do, the current URL is a representation of our properties.

--- a/iron-query-params.html
+++ b/iron-query-params.html
@@ -49,7 +49,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (this._dontReact) {
         return;
       }
-      this.paramsString = this._encodeParams(this.paramsObject);
+      this.paramsString = this._encodeParams(this.paramsObject)
+          .replace(/%3F/g, '?').replace(/%2F/g, '/');
     },
     _encodeParams: function(params) {
       var encodedParams = [];

--- a/test/index.html
+++ b/test/index.html
@@ -19,7 +19,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       WCT.loadSuites([
         'iron-location.html',
         'iron-query-params.html',
-        'initialization-tests.html'
+        'initialization-tests.html',
+        'integration.html'
       ]);
     </script>
   </body>

--- a/test/integration.html
+++ b/test/integration.html
@@ -36,8 +36,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </iron-query-params>
     </template>
     <script>
-      Polymer({
-        is: 'integration-element'
+      HTMLImports.whenReady(function() {
+        Polymer({
+          is: 'integration-element'
+        });
       });
     </script>
   </dom-module>

--- a/test/integration.html
+++ b/test/integration.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <title>iron-location</title>
+
+  <script src="../../webcomponentsjs/webcomponents.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../../polymer/polymer.html">
+  <link rel="import" href="../../promise-polyfill/promise-polyfill.html">
+  <link rel="import" href="../iron-query-params.html">
+  <link rel="import" href="../iron-location.html">
+</head>
+<body>
+  <dom-module id="integration-element">
+    <template>
+      <iron-location
+          id="location"
+          path="{{path}}"
+          query="{{query}}"
+          hash="{{hash}}">
+      </iron-location>
+      <iron-query-params
+          id="queryParams"
+          params-string="{{query}}"
+          params-object="{{queryParams}}">
+      </iron-query-params>
+    </template>
+    <script>
+      Polymer({
+        is: 'integration-element'
+      });
+    </script>
+  </dom-module>
+
+  <test-fixture id="Integration">
+    <template>
+      <integration-element></integration-element>
+    </template>
+  </test-fixture>
+
+  <script>
+    'use strict';
+
+    suite('Integration tests', function () {
+
+      var integration;
+      var ironLocation;
+      var ironQueryParams;
+
+      setup(function() {
+        integration = fixture('Integration');
+        ironLocation = integration.$.location;
+        ironQueryParams = integration.$.queryParams;
+      });
+
+      test('propagations from location to iqp', function() {
+        var queryEncodingExamples = {
+          'foo': '?foo',
+          '': '',
+          'foo bar': '?foo%20bar',
+          'foo#bar': '?foo%23bar',
+          'foo?bar': '?foo?bar',
+          '/foo\'bar\'baz': ['?/foo%27bar%27baz', '?/foo\'bar\'baz'],
+          'foo/bar/baz': '?foo/bar/baz'
+        };
+        for (var plainTextQuery in queryEncodingExamples) {
+          var encodedQueries = queryEncodingExamples[plainTextQuery];
+          var ironLocationQuery = encodedQueries;
+          if (typeof encodedQueries === 'string') {
+            encodedQueries = [encodedQueries];
+            ironLocationQuery = [ironLocationQuery.substring(1)];
+          } else {
+            ironLocationQuery = ironLocationQuery.map(function(value) {
+              return value.substring(1);
+            });
+          }
+
+          ironLocation.query = plainTextQuery;
+          expect(encodedQueries).to.contain(window.location.search);
+          expect(ironLocationQuery).to.contain(ironLocation.query);
+          expect(ironLocationQuery).to.contain(ironQueryParams.paramsString);
+          if (plainTextQuery) {
+            console.log(ironQueryParams.paramsObject);
+            expect('').to.be.equal(ironQueryParams.paramsObject[plainTextQuery])
+          } else {
+            expect(ironQueryParams.paramsObject[plainTextQuery]).to.be.undefined;          
+          }
+        }
+      });
+
+      test('propagations from iqp to location', function() {
+        var queryEncodingExamples = {
+          'foo': '?foo',
+          '': '',
+          'foo bar': '?foo%20bar',
+          'foo#bar': '?foo%23bar',
+          'foo?bar': '?foo?bar',
+          '/foo\'bar\'baz': ['?/foo%27bar%27baz', '?/foo\'bar\'baz'],
+          'foo/bar/baz': '?foo/bar/baz'
+        };
+        for (var plainTextQuery in queryEncodingExamples) {
+          var encodedQueries = queryEncodingExamples[plainTextQuery];
+          var ironLocationQuery = encodedQueries;
+          if (typeof encodedQueries === 'string') {
+            encodedQueries = [encodedQueries];
+            ironLocationQuery = [ironLocationQuery.substring(1)];
+          } else {
+            ironLocationQuery = ironLocationQuery.map(function(value) {
+              return value.substring(1);
+            });
+          }
+
+          var newParamsObject = {};
+          newParamsObject[plainTextQuery] = '';
+
+          ironQueryParams.paramsObject = newParamsObject;
+          expect(encodedQueries).to.contain(window.location.search);
+          expect(ironLocationQuery).to.contain(ironLocation.query);
+        }
+      });
+    });
+
+  </script>
+</body>

--- a/test/integration.html
+++ b/test/integration.html
@@ -92,7 +92,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(ironLocationQuery).to.contain(ironLocation.query);
           expect(ironLocationQuery).to.contain(ironQueryParams.paramsString);
           if (plainTextQuery) {
-            console.log(ironQueryParams.paramsObject);
             expect('').to.be.equal(ironQueryParams.paramsObject[plainTextQuery])
           } else {
             expect(ironQueryParams.paramsObject[plainTextQuery]).to.be.undefined;          

--- a/test/iron-location.html
+++ b/test/iron-location.html
@@ -205,7 +205,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         };
         for (var plainTextQuery in queryEncodingExamples) {
           var encodedQueries = queryEncodingExamples[plainTextQuery];
-          var ironLocationQuery = encodedQueries;
+          var ironLocationQuery = queryEncodingExamples[plainTextQuery];
           if (typeof encodedQueries === 'string') {
             encodedQueries = [encodedQueries];
             ironLocationQuery = [ironLocationQuery.substring(1)];
@@ -217,6 +217,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           expect(urlElem._initialized).to.be.eq(true);
           urlElem.query = plainTextQuery;
+          expect(encodedQueries).to.contain(window.location.search);
+          expect(ironLocationQuery).to.contain(urlElem.query);
+          expect(ironLocationQuery).to.contain(makeTemporaryIronLocation().query);
+
+          urlElem.query = 'dummyValue';
+          urlElem.query = ironLocationQuery[0];
+
           expect(encodedQueries).to.contain(window.location.search);
           expect(ironLocationQuery).to.contain(urlElem.query);
           expect(ironLocationQuery).to.contain(makeTemporaryIronLocation().query);

--- a/test/iron-location.html
+++ b/test/iron-location.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <title>iron-location</title>
 
-  <script src="../../webcomponentsjs/webcomponents.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
 
   <link rel="import" href="../../polymer/polymer.html">

--- a/test/iron-location.html
+++ b/test/iron-location.html
@@ -201,18 +201,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           'foo#bar': '?foo%23bar',
           'foo?bar': '?foo?bar',
           '/foo\'bar\'baz': ['?/foo%27bar%27baz', '?/foo\'bar\'baz'],
+          'foo/bar/baz': '?foo/bar/baz'
         };
         for (var plainTextQuery in queryEncodingExamples) {
           var encodedQueries = queryEncodingExamples[plainTextQuery];
+          var ironLocationQuery = encodedQueries;
           if (typeof encodedQueries === 'string') {
             encodedQueries = [encodedQueries];
+            ironLocationQuery = [ironLocationQuery.substring(1)];
+          } else {
+            ironLocationQuery = ironLocationQuery.map(function(value) {
+              return value.substring(1);
+            });
           }
 
           expect(urlElem._initialized).to.be.eq(true);
           urlElem.query = plainTextQuery;
           expect(encodedQueries).to.contain(window.location.search);
-          expect(urlElem.query).to.be.equal(plainTextQuery);
-          expect(makeTemporaryIronLocation().query).to.be.equal(plainTextQuery);
+          expect(ironLocationQuery).to.contain(urlElem.query);
+          expect(ironLocationQuery).to.contain(makeTemporaryIronLocation().query);
         }
       });
       test('assigning to a relative path URL', function() {

--- a/test/iron-location.html
+++ b/test/iron-location.html
@@ -205,15 +205,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         };
         for (var plainTextQuery in queryEncodingExamples) {
           var encodedQueries = queryEncodingExamples[plainTextQuery];
-          var ironLocationQuery = queryEncodingExamples[plainTextQuery];
           if (typeof encodedQueries === 'string') {
             encodedQueries = [encodedQueries];
-            ironLocationQuery = [ironLocationQuery.substring(1)];
-          } else {
-            ironLocationQuery = ironLocationQuery.map(function(value) {
-              return value.substring(1);
-            });
           }
+          
+          var ironLocationQuery = encodedQueries.map(function(value) {
+            return value.substring(1);
+          });
 
           expect(urlElem._initialized).to.be.eq(true);
           urlElem.query = plainTextQuery;

--- a/test/iron-query-params.html
+++ b/test/iron-query-params.html
@@ -67,7 +67,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             object: {'monster kid:': '😿'}
           },
           {
-            string: 'yes%2C%20ok%3F%20what%20is%20up%20with%20%CB%9Athiiis%CB%9A=%E2%98%83',
+            string: 'yes%2C%20ok?%20what%20is%20up%20with%20%CB%9Athiiis%CB%9A=%E2%98%83',
             object: {'yes, ok? what is up with ˚thiiis˚': '☃'}
           },
         ];

--- a/test/iron-query-params.html
+++ b/test/iron-query-params.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <title>iron-location</title>
 
-  <script src="../../webcomponentsjs/webcomponents.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
 
   <link rel="import" href="../../polymer/polymer.html">


### PR DESCRIPTION
This will no longer decode window.location.search. Also leaves `/` and `?` alone.