### PR TITLE
prevents infinite loop with '

### DIFF
--- a/iron-query-params.html
+++ b/iron-query-params.html
@@ -50,7 +50,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return;
       }
       this.paramsString = this._encodeParams(this.paramsObject)
-          .replace(/%3F/g, '?').replace(/%2F/g, '/');
+          .replace(/%3F/g, '?').replace(/%2F/g, '/').replace("'", '%27');
     },
     _encodeParams: function(params) {
       var encodedParams = [];

--- a/test/iron-query-params.html
+++ b/test/iron-query-params.html
@@ -63,8 +63,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             object: {'debug': '', 'ok': ''}
           },
           {
-            string: 'monster%20kid%3A=%F0%9F%98%BF',
-            object: {'monster kid:': '😿'}
+            string: 'monster%20kid%3A=%F0%9F%98%BF&quote=%27',
+            object: {'monster kid:': '😿', 'quote': '\''}
           },
           {
             string: 'yes%2C%20ok?%20what%20is%20up%20with%20%CB%9Athiiis%CB%9A=%E2%98%83',


### PR DESCRIPTION
fixes PolymerElements/app-route#162 and PolymerElements/app-route#157. Required for  PolymerElements/app-route#163

When `'` is put in the `window.location`, the browser automatically sets it to `%27` which causes a discrepancy with `paramsString` and the `window.location`'s query params. This results in an infinite loop when `iron-query-params` is properly linked up to `iron-location`. (see PolymerElements/app-route#162 and PolymerElements/app-route#157)