### PR TITLE
Fix misspelled property name

### DIFF
--- a/test/initialization-cases.html
+++ b/test/initialization-cases.html
@@ -15,7 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer({
     is: 'default-value',
     properties: {
-      val: {
+      value: {
         type: String,
         notify: true,
         value: 'default-value'


### PR DESCRIPTION
Found while developing the new linter. Looks like this is my bad, and it was defeating the purpose of some of these tests!

We're getting a failure in Edge but it appears to be unrelated: https://travis-ci.org/PolymerElements/iron-location/builds/204068634