### PR TITLE
Fixed decoding removed/destroys query parameters

### DIFF
--- a/iron-query-params.html
+++ b/iron-query-params.html
@@ -56,8 +56,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (this._dontReact) {
         return;
       }
-      this.paramsString = this._encodeParams(this.paramsObject)
-          .replace(/%3F/g, '?').replace(/%2F/g, '/').replace(/'/g, '%27');
+      let _encParams = this._encodeParams(this.paramsObject)
+                .replace(/%3F/g, '?').replace(/%2F/g, '/').replace(/'/g, '%27');
+
+      //Only set paramsString if encoding return non empty object
+      if (_encParams) {
+          this.paramsString = _encParams;
+      }
     },
 
     _encodeParams: function(params) {


### PR DESCRIPTION
The `_encodeParams` function always returns an empty object when first loading the `iron-query-params` object which removes all query parameters when refreshing a page or after a file get's lazy loaded. 

In short this happened: `https://<host>/test?a=5` will be transformed into `http://<host>/test`.