### PR TITLE
Removed paramsObject default value

### DIFF
--- a/iron-query-params.html
+++ b/iron-query-params.html
@@ -26,10 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       paramsObject: {
         type: Object,
-        notify: true,
-        value: function() {
-          return {};
-        }
+        notify: true
       },
 
       _dontReact: {


### PR DESCRIPTION
Removed default initialization of `paramsObject` to avoid unnecessary `queryString` override.
Related with #83.