### PR TITLE
Fix loading i-q-p async / lazily causing overwrite

### DIFF
--- a/iron-query-params.d.ts
+++ b/iron-query-params.d.ts
@@ -13,9 +13,15 @@
 interface IronQueryParamsElement extends Polymer.Element {
   paramsString: string|null|undefined;
   paramsObject: object|null|undefined;
+
+  /**
+   * next major bump.
+   */
+  lazyLoaded: boolean|null|undefined;
   _dontReact: boolean|null|undefined;
   hostAttributes: object|null;
   paramsStringChanged(): void;
+  detached(): void;
   paramsObjectChanged(): void;
   _encodeParams(params: any): any;
   _decodeParams(paramString: any): any;

--- a/iron-query-params.html
+++ b/iron-query-params.html
@@ -32,6 +32,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
 
+      // TODO(emarquez): remove this property and paramsObject inital value on
+      // next major bump.
+      lazyLoaded: {
+        type: Boolean,
+        value: false
+      },
+
       _dontReact: {
         type: Boolean,
         value: false
@@ -43,7 +50,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     observers: [
-      'paramsObjectChanged(paramsObject.*)'
+      'paramsObjectChanged(paramsObject.*, lazyLoaded)'
     ],
 
     paramsStringChanged: function() {
@@ -52,10 +59,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._dontReact = false;
     },
 
+    detached: function() {
+      this.__ignoreLazy = false;
+    },
+
     paramsObjectChanged: function() {
-      if (this._dontReact) {
+      if (this._dontReact || (this.lazyLoaded && !this.__ignoreLazy)) {
+        this.__ignoreLazy = true;
         return;
       }
+
       this.paramsString = this._encodeParams(this.paramsObject)
           .replace(/%3F/g, '?').replace(/%2F/g, '/').replace(/'/g, '%27');
     },


### PR DESCRIPTION
Addresses #83 and #86 in a non-breaking context. If `iron-query-params` is loaded after databinding. This keeps the behavior the same unless `lazy-loaded` is set to true on the element.

This cannot be repro'd on a jsbin due to their environment not liking reloads, but [here is a gist](https://gist.github.com/e111077/1f99d538bd4d8855cb31ba16cdba6318).

example of usage: `<iron-query-params lazy-loaded></iron-query-params>`

After releasing this PR as a patch, I would like to merge and release #86 as a permanent fix on a major version bump. WDYT?