### PR TITLE
Fix: prevent overriding queryParams before parsing

### DIFF
--- a/iron-query-params.html
+++ b/iron-query-params.html
@@ -21,6 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       paramsString: {
         type: String,
         notify: true,
+        value: '',
         observer: 'paramsStringChanged',
       },
 
@@ -33,6 +34,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       _dontReact: {
+        type: Boolean,
+        value: false,
+      },
+
+      _init: {
         type: Boolean,
         value: true,
       }
@@ -53,7 +59,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     paramsObjectChanged: function() {
-      if (this._dontReact) {
+      if (Object.keys(this.paramsObject).length) {
+        this._init = false;
+      }
+      if (this._dontReact || this._init) {
         return;
       }
       this.paramsString = this._encodeParams(this.paramsObject)

--- a/iron-query-params.html
+++ b/iron-query-params.html
@@ -34,7 +34,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _dontReact: {
         type: Boolean,
-        value: false
+        value: true,
       }
     },
 

--- a/test/iron-query-params.html
+++ b/test/iron-query-params.html
@@ -26,6 +26,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <iron-query-params></iron-query-params>
     </template>
   </test-fixture>
+  <test-fixture id="PresetQueryParams">
+    <template>
+      <iron-query-params
+        params-string="a=b"
+      ></iron-query-params>
+    </template>
+  </test-fixture>
 
   <script>
     'use strict';
@@ -95,6 +102,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         paramsElem.paramsString = 'key=value+with+spaces';
         expect(paramsElem.paramsObject).to.deep.equal(
             {key: 'value with spaces'});
+      });
+    });
+
+    // NOTE: This is exactly how iron-query-params is used within app-location
+    suite('<iron-query-params query-string="a=b">', function() {
+      var paramsElem;
+      setup(function() {
+        paramsElem = fixture('PresetQueryParams');
+      });
+
+      test('initializing with presets', function() {
+        expect(paramsElem.paramsString).to.be.eq('a=b');
+        expect(paramsElem.paramsObject).to.deep.equal(
+          {a: 'b'});
       });
     });
 


### PR DESCRIPTION
Turns out that the default value of an empty object is triggering updates to rewrite the queryParams in the URL before the other logic has a chance to parse it.