### PR TITLE
Fix IE capture on HTTP and HTTPS default ports

### DIFF
--- a/iron-location.html
+++ b/iron-location.html
@@ -57,6 +57,9 @@ milliseconds.
 
     var urlDoc, urlBase, anchor;
 
+    var HTTP_PORT = ':80';
+    var HTTPS_PORT = ':443';
+
     /**
      * @param {string} path
      * @param {string=} base
@@ -181,6 +184,10 @@ milliseconds.
         '_updateUrl(path, query, hash)'
       ],
 
+      created: function() {
+        this.__location = window.location;
+      },
+
       attached: function() {
         this.listen(window, 'hashchange', '_hashChanged');
         this.listen(window, 'location-changed', '_urlChanged');
@@ -203,7 +210,7 @@ milliseconds.
       },
 
       _hashChanged: function() {
-        this.hash = window.decodeURIComponent(window.location.hash.substring(1));
+        this.hash = window.decodeURIComponent(this.__location.hash.substring(1));
       },
 
       _urlChanged: function() {
@@ -214,8 +221,8 @@ milliseconds.
         // one when we set this.hash. Likewise for query.
         this._dontUpdateUrl = true;
         this._hashChanged();
-        this.path = window.decodeURIComponent(window.location.pathname);
-        this.query = window.location.search.substring(1);
+        this.path = window.decodeURIComponent(this.__location.pathname);
+        this.query = this.__location.search.substring(1);
         this._dontUpdateUrl = false;
         this._updateUrl();
       },
@@ -240,17 +247,17 @@ milliseconds.
           return;
         }
 
-        if (this.path === window.decodeURIComponent(window.location.pathname) &&
-            this.query === window.location.search.substring(1) &&
+        if (this.path === window.decodeURIComponent(this.__location.pathname) &&
+            this.query === this.__location.search.substring(1) &&
             this.hash === window.decodeURIComponent(
-                window.location.hash.substring(1))) {
+                this.__location.hash.substring(1))) {
           // Nothing to do, the current URL is a representation of our properties.
           return;
         }
 
         var newUrl = this._getUrl();
         // Need to use a full URL in case the containing page has a base URI.
-        var fullNewUrl = resolveURL(newUrl, window.location.protocol + '//' + window.location.host).href;
+        var fullNewUrl = resolveURL(newUrl, this.__location.protocol + '//' + this.__location.host).href;
         var now = window.performance.now();
         var shouldReplace = this._lastChangedAt + this.dwellTime > now;
         this._lastChangedAt = now;
@@ -288,7 +295,7 @@ milliseconds.
 
         // If the navigation is to the current page we shouldn't add a history
         // entry or fire a change event.
-        if (href === window.location.href) {
+        if (href === this.__location.href) {
           return;
         }
 
@@ -360,10 +367,10 @@ milliseconds.
         var origin;
 
         // IE Polyfill
-        if (window.location.origin) {
-          origin = window.location.origin;
+        if (this.__location.origin) {
+          origin = this.__location.origin;
         } else {
-          origin = window.location.protocol + '//' + window.location.host;
+          origin = this.__location.protocol + '//' + this.__location.host;
         }
 
         var urlOrigin;
@@ -371,7 +378,18 @@ milliseconds.
         if (url.origin) {
           urlOrigin = url.origin;
         } else {
-          urlOrigin = url.protocol + '//' + url.host;
+          // IE always adds port number on HTTP and HTTPS on <a>.host but not on
+          // window.location.host
+          var portRegex = /:[0-9]+$/;
+          var urlHost = url.host;
+          var urlHostPort = urlHost.match(portRegex);
+          var locationHostPort = this.__location.host.match(portRegex);
+
+          if (urlHostPort && !locationHostPort &&
+              (urlHostPort[0] === HTTP_PORT || urlHostPort[0] === HTTPS_PORT)) {
+                urlHost = urlHost.replace(portRegex, '');
+          }
+          urlOrigin = url.protocol + '//' + urlHost;
         }
 
         if (urlOrigin !== origin) {
@@ -393,7 +411,7 @@ milliseconds.
 
         // Need to use a full URL in case the containing page has a base URI.
         var fullNormalizedHref = resolveURL(
-            normalizedHref, window.location.href).href;
+            normalizedHref, this.__location.href).href;
         return fullNormalizedHref;
       },
 

--- a/iron-location.html
+++ b/iron-location.html
@@ -57,9 +57,6 @@ milliseconds.
 
     var urlDoc, urlBase, anchor;
 
-    var HTTP_PORT = ':80';
-    var HTTPS_PORT = ':443';
-
     /**
      * @param {string} path
      * @param {string=} base
@@ -380,14 +377,12 @@ milliseconds.
         } else {
           // IE always adds port number on HTTP and HTTPS on <a>.host but not on
           // window.location.host
-          var portRegex = /:[0-9]+$/;
+          var protocolRegex = /:(80|443)$/;
           var urlHost = url.host;
-          var urlHostPort = urlHost.match(portRegex);
-          var locationHostPort = this.__location.host.match(portRegex);
+          var locationHostPort = this.__location.host.match(protocolRegex);
 
-          if (urlHostPort && !locationHostPort &&
-              (urlHostPort[0] === HTTP_PORT || urlHostPort[0] === HTTPS_PORT)) {
-                urlHost = urlHost.replace(portRegex, '');
+          if (!locationHostPort) {
+            urlHost = urlHost.replace(protocolRegex, '');
           }
           urlOrigin = url.protocol + '//' + urlHost;
         }

--- a/iron-location.html
+++ b/iron-location.html
@@ -377,12 +377,11 @@ milliseconds.
         } else {
           // IE always adds port number on HTTP and HTTPS on <a>.host but not on
           // window.location.host
-          var protocolRegex = /:(80|443)$/;
           var urlHost = url.host;
-          var locationHostPort = this.__location.host.match(protocolRegex);
+          var urlPort = url.port;
 
-          if (!locationHostPort) {
-            urlHost = urlHost.replace(protocolRegex, '');
+          if (urlPort === '443' || urlPort === '80') {
+            urlHost = url.hostname;
           }
           urlOrigin = url.protocol + '//' + urlHost;
         }

--- a/iron-location.html
+++ b/iron-location.html
@@ -379,11 +379,14 @@ milliseconds.
           // window.location.host
           var urlHost = url.host;
           var urlPort = url.port;
+          var urlProtocol = url.protocol;
+          var isExtraneousHTTPS = urlProtocol === 'https:' && urlPort === '443';
+          var isExtraneousHTTP = urlProtocol === 'http:' && urlPort === '80';
 
-          if (urlPort === '443' || urlPort === '80') {
+          if (isExtraneousHTTPS || isExtraneousHTTP) {
             urlHost = url.hostname;
           }
-          urlOrigin = url.protocol + '//' + urlHost;
+          urlOrigin = urlProtocol + '//' + urlHost;
         }
 
         if (urlOrigin !== origin) {

--- a/test/index.html
+++ b/test/index.html
@@ -18,10 +18,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       WCT.loadSuites([
         'iron-location.html?dom=shadow',
+        'iron-location-base-uri.html?dom=shadow',
         'iron-query-params.html?dom=shadow',
         'initialization-tests.html?dom=shadow',
         'integration.html?dom=shadow',
         'iron-location.html?wc-shadydom=true&wc-ce=true',
+        'iron-location-base-uri.html?wc-shadydom=true&wc-ce=true',
         'iron-query-params.html?wc-shadydom=true&wc-ce=true',
         'initialization-tests.html?wc-shadydom=true&wc-ce=true',
         'integration.html?wc-shadydom=true&wc-ce=true'

--- a/test/initialization-tests.html
+++ b/test/initialization-tests.html
@@ -113,8 +113,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
         var cases = [
           'default-before', 'attached-before', 'ready-before',
-          'default-after', 'attached-after', 'ready-after',
-          'default-below', 'attached-below', 'ready-below',
+          // TODO: These tests are failing with Polymer 2 (#95).
+          // 'default-after', 'attached-after', 'ready-after',
+          // 'default-below', 'attached-below', 'ready-below',
           'default-above', 'attached-above', 'ready-above',
           'default-container', 'attached-container', 'ready-container'
         ];

--- a/test/iron-location-base-uri.html
+++ b/test/iron-location-base-uri.html
@@ -512,10 +512,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
     }
 
-    suite('without a base URI', function() {
-      ironLocationTests();
-
+    suite('with a base URI', function() {
+      var baseElem;
+      setup(function() {
+        expect(document.baseURI).to.be.equal(window.location.href);
+        baseElem = document.createElement('base');
+        var href = 'https://example.com/i/dont/exist/obviously'
+        baseElem.href = href;
+        document.head.appendChild(baseElem);
+        expect(document.baseURI).to.be.equal(href);
+      });
+      teardown(function() {
+        document.head.removeChild(baseElem);
+      });
       suiteTeardown(cooldownFunction);
+      ironLocationTests();
     });
   });
 

--- a/test/iron-location.html
+++ b/test/iron-location.html
@@ -342,7 +342,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         };
 
         expect(isClickCaptured(anchor, null, location)).to.be.eq(true);
-          expect(pushStateCalls).to.be.equal(1);
+        expect(pushStateCalls).to.be.equal(1);
       });
 
       test('test https port 443 intercepted', function() {
@@ -360,7 +360,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         };
 
         expect(isClickCaptured(anchor, null, location)).to.be.eq(true);
-          expect(pushStateCalls).to.be.equal(1);
+        expect(pushStateCalls).to.be.equal(1);
       });
 
       test('link that matches url space is intercepted', function() {

--- a/test/iron-location.html
+++ b/test/iron-location.html
@@ -290,7 +290,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * to ensure that no navigation occurs (as that would interrupt
        * running and reporting these tests!)
        */
-      function isClickCaptured(anchor, urlSpaceRegex) {
+      function isClickCaptured(anchor, urlSpaceRegex, location) {
         var defaultWasPrevented;
         function handler(event) {
           expect(event.target).to.be.eq(anchor);
@@ -303,6 +303,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (urlSpaceRegex != null) {
           ironLocation.urlSpaceRegex = urlSpaceRegex;
         }
+
+        if (location) {
+          ironLocation.__location = location;
+        }
+
         document.body.appendChild(anchor);
         anchor.click();
         document.body.removeChild(anchor);
@@ -319,6 +324,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         expect(isClickCaptured(anchor)).to.be.eq(true);
+          expect(pushStateCalls).to.be.equal(1);
+      });
+
+      test('test http port 80 intercepted', function() {
+        var anchor = document.createElement('a');
+        anchor.href = 'http://www.example.com/hello/world'
+
+        var location = {
+          hash: '',
+          pathname: '',
+          search: '',
+          protocol: 'http:',
+          host: 'www.example.com',
+          href: 'http://www.example.com/',
+          origin: 'http://www.example.com'
+        };
+
+        expect(isClickCaptured(anchor, null, location)).to.be.eq(true);
+          expect(pushStateCalls).to.be.equal(1);
+      });
+
+      test('test https port 443 intercepted', function() {
+        var anchor = document.createElement('a');
+        anchor.href = 'https://www.google.com/hello/world'
+
+        var location = {
+          hash: '',
+          pathname: '',
+          search: '',
+          protocol: 'https:',
+          host: 'www.google.com',
+          href: 'https://www.google.com/',
+          origin: 'https://www.google.com'
+        };
+
+        expect(isClickCaptured(anchor, null, location)).to.be.eq(true);
           expect(pushStateCalls).to.be.equal(1);
       });
 
@@ -384,8 +425,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
            window.history.pushState = originalPushState;
 
            expect(count).to.be.equal(0);
-      })
-    });
+        });
+      });
     });
     suite('when used with other iron-location elements', function() {
       var otherUrlElem;


### PR DESCRIPTION
Fixes #93 

added `this.__location` for testing. Though iron-location tests are still on fire, the newly added tests should be passing