### PR TITLE
Automatic format!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ before_script:
     npm run update-types && git diff --exit-code || (echo -e
     '\n\033[31mERROR:\033[0m Typings are stale. Please run "npm run
     update-types".' && false)
+  - >-
+    npm run format && git diff --exit-code || (echo -e '\n\033[31mERROR:\033[0m
+    Typings are stale. Please run "npm run format".' && false)
 script:
   - xvfb-run polymer test
   - >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
     update-types".' && false)
   - >-
     npm run format && git diff --exit-code || (echo -e '\n\033[31mERROR:\033[0m
-    Typings are stale. Please run "npm run format".' && false)
+    Project is not formatted. Please run "npm run format".' && false)
 script:
   - xvfb-run polymer test
   - >-

--- a/demo/index.html
+++ b/demo/index.html
@@ -93,18 +93,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         Polymer({
           is: 'iron-location-demo',
           properties: {
-            historyElementsAdded: {
-              type: Number
-            },
+            historyElementsAdded: {type: Number},
 
-            dwellTime: {
-              type: Number,
-              value: 2000
-            }
+            dwellTime: {type: Number, value: 2000}
           },
-          observers: [
-            'checkHistorySize(path, hash, query, startingHistoryLength)'
-          ],
+          observers: ['checkHistorySize(path, hash, query, startingHistoryLength)'],
 
           ready: function() {
             this.startingHistoryLength = window.history.length;

--- a/demo/iron-query-params.html
+++ b/demo/iron-query-params.html
@@ -58,33 +58,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         Polymer({
           is: 'iron-query-params-demo',
           properties: {
-            params: {
-              observer: 'paramsChanged'
-            },
+            params: {observer: 'paramsChanged'},
 
             paramsInvalid: {
               value: false,
             },
 
-            paramString: {
-              type: String,
-              observer: 'paramStringChanged'
-            },
+            paramString: {type: String, observer: 'paramStringChanged'},
 
-            stringifiedParams: {
-              type: String,
-              observer: 'stringifedParamsChanged'
-            }
+            stringifiedParams: {type: String, observer: 'stringifedParamsChanged'}
           },
 
           paramStringChanged: function() {
-            if (this.ignore) { return; }
+            if (this.ignore) {
+              return;
+            }
 
             this.ignore = true;
 
             try {
               this.paramsInvalid = false;
-            } catch(_) {
+            } catch (_) {
               this.paramsInvalid = true;
             }
 
@@ -92,7 +86,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           },
 
           stringifedParamsChanged: function() {
-            if (this.ignore) { return; }
+            if (this.ignore) {
+              return;
+            }
 
             this.ignore = true;
 
@@ -109,7 +105,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           },
 
           paramsChanged: function() {
-            if (this.ignore) { return; }
+            if (this.ignore) {
+              return;
+            }
 
             this.ignore = true;
             this.stringifiedParams = JSON.stringify(this.params);

--- a/iron-location.d.ts
+++ b/iron-location.d.ts
@@ -86,8 +86,8 @@ interface IronLocationElement extends Polymer.Element {
   urlSpaceRegex: string|RegExp|null;
 
   /**
-   * A flag that specifies whether the spaces in query that would normally be encoded as %20 should be
-   * encoded as +.
+   * A flag that specifies whether the spaces in query that would normally be
+   * encoded as %20 should be encoded as +.
    *
    * Given an example text "hello world", it is encoded in query as
    * - "hello%20world" without the parameter

--- a/iron-location.html
+++ b/iron-location.html
@@ -51,391 +51,383 @@ milliseconds.
  -->
 <script>
   (function() {
-    'use strict';
+  'use strict';
 
-    var workingURL;
+  var workingURL;
 
-    var urlDoc, urlBase, anchor;
+  var urlDoc, urlBase, anchor;
+
+  /**
+   * @param {string} path
+   * @param {string=} base
+   * @return {!URL|!HTMLAnchorElement}
+   */
+  function resolveURL(path, base) {
+    if (workingURL === undefined) {
+      workingURL = false;
+      try {
+        var u = new URL('b', 'http://a');
+        u.pathname = 'c%20d';
+        workingURL = (u.href === 'http://a/c%20d');
+        workingURL = workingURL &&
+            (new URL('http://www.google.com/?foo bar').href ===
+             'http://www.google.com/?foo%20bar');
+      } catch (e) {
+      }
+    }
+    if (workingURL) {
+      return new URL(path, base);
+    }
+    if (!urlDoc) {
+      urlDoc = document.implementation.createHTMLDocument('url');
+      urlBase = urlDoc.createElement('base');
+      urlDoc.head.appendChild(urlBase);
+      anchor = /** @type {HTMLAnchorElement}*/ (urlDoc.createElement('a'));
+    }
+    urlBase.href = base;
+    anchor.href = path.replace(/ /g, '%20');
+    return anchor;
+  }
+
+  Polymer({
+    is: 'iron-location',
+
+    properties: {
+      /**
+       * The pathname component of the URL.
+       */
+      path: {
+        type: String,
+        notify: true,
+        value: function() {
+          return window.decodeURIComponent(window.location.pathname);
+        }
+      },
+
+      /**
+       * The query string portion of the URL.
+       */
+      query: {
+        type: String,
+        notify: true,
+        value: function() {
+          return window.location.search.slice(1);
+        }
+      },
+
+      /**
+       * The hash component of the URL.
+       */
+      hash: {
+        type: String,
+        notify: true,
+        value: function() {
+          return window.decodeURIComponent(window.location.hash.slice(1));
+        }
+      },
+
+      /**
+       * If the user was on a URL for less than `dwellTime` milliseconds, it
+       * won't be added to the browser's history, but instead will be replaced
+       * by the next entry.
+       *
+       * This is to prevent large numbers of entries from clogging up the user's
+       * browser history. Disable by setting to a negative number.
+       */
+      dwellTime: {type: Number, value: 2000},
+
+      /**
+       * A regexp that defines the set of URLs that should be considered part
+       * of this web app.
+       *
+       * Clicking on a link that matches this regex won't result in a full page
+       * navigation, but will instead just update the URL state in place.
+       *
+       * This regexp is given everything after the origin in an absolute
+       * URL. So to match just URLs that start with /search/ do:
+       *     url-space-regex="^/search/"
+       *
+       * @type {string|RegExp}
+       */
+      urlSpaceRegex: {type: String, value: ''},
+
+      /**
+       * A flag that specifies whether the spaces in query that would normally be
+       * encoded as %20 should be encoded as +.
+       *
+       * Given an example text "hello world", it is encoded in query as
+       * - "hello%20world" without the parameter
+       * - "hello+world" with the parameter
+       */
+      encodeSpaceAsPlusInQuery: {type: Boolean, value: false},
+
+      /**
+       * urlSpaceRegex, but coerced into a regexp.
+       *
+       * @type {RegExp}
+       */
+      _urlSpaceRegExp: {computed: '_makeRegExp(urlSpaceRegex)'},
+
+      _lastChangedAt: {type: Number},
+
+      _initialized: {type: Boolean, value: false}
+    },
+
+    hostAttributes: {hidden: true},
+
+    observers: ['_updateUrl(path, query, hash)'],
+
+    created: function() {
+      this.__location = window.location;
+    },
+
+    attached: function() {
+      this.listen(window, 'hashchange', '_hashChanged');
+      this.listen(window, 'location-changed', '_urlChanged');
+      this.listen(window, 'popstate', '_urlChanged');
+      this.listen(
+          /** @type {!HTMLBodyElement} */ (document.body),
+          'click',
+          '_globalOnClick');
+      // Give a 200ms grace period to make initial redirects without any
+      // additions to the user's history.
+      this._lastChangedAt = window.performance.now() - (this.dwellTime - 200);
+      this._initialized = true;
+
+      this._urlChanged();
+    },
+
+    detached: function() {
+      this.unlisten(window, 'hashchange', '_hashChanged');
+      this.unlisten(window, 'location-changed', '_urlChanged');
+      this.unlisten(window, 'popstate', '_urlChanged');
+      this.unlisten(
+          /** @type {!HTMLBodyElement} */ (document.body),
+          'click',
+          '_globalOnClick');
+      this._initialized = false;
+    },
+
+    _hashChanged: function() {
+      this.hash = window.decodeURIComponent(this.__location.hash.substring(1));
+    },
+
+    _urlChanged: function() {
+      // We want to extract all info out of the updated URL before we
+      // try to write anything back into it.
+      //
+      // i.e. without _dontUpdateUrl we'd overwrite the new path with the old
+      // one when we set this.hash. Likewise for query.
+      this._dontUpdateUrl = true;
+      this._hashChanged();
+      this.path = window.decodeURIComponent(this.__location.pathname);
+      this.query = this.__location.search.substring(1);
+      this._dontUpdateUrl = false;
+      this._updateUrl();
+    },
+
+    _getUrl: function() {
+      var partiallyEncodedPath =
+          window.encodeURI(this.path).replace(/\#/g, '%23').replace(/\?/g, '%3F');
+      var partiallyEncodedQuery = '';
+      if (this.query) {
+        partiallyEncodedQuery = '?' + this.query.replace(/\#/g, '%23');
+        if (this.encodeSpaceAsPlusInQuery) {
+          partiallyEncodedQuery = partiallyEncodedQuery.replace(/\+/g, '%2B')
+                                      .replace(/ /g, '+')
+                                      .replace(/%20/g, '+');
+        }
+      }
+      var partiallyEncodedHash = '';
+      if (this.hash) {
+        partiallyEncodedHash = '#' + window.encodeURI(this.hash);
+      }
+      return (
+          partiallyEncodedPath + partiallyEncodedQuery + partiallyEncodedHash);
+    },
+
+    _updateUrl: function() {
+      if (this._dontUpdateUrl || !this._initialized) {
+        return;
+      }
+
+      if (this.path === window.decodeURIComponent(this.__location.pathname) &&
+          this.query === this.__location.search.substring(1) &&
+          this.hash ===
+              window.decodeURIComponent(this.__location.hash.substring(1))) {
+        // Nothing to do, the current URL is a representation of our properties.
+        return;
+      }
+
+      var newUrl = this._getUrl();
+      // Need to use a full URL in case the containing page has a base URI.
+      var fullNewUrl =
+          resolveURL(
+              newUrl, this.__location.protocol + '//' + this.__location.host)
+              .href;
+      var now = window.performance.now();
+      var shouldReplace = this._lastChangedAt + this.dwellTime > now;
+      this._lastChangedAt = now;
+
+      if (shouldReplace) {
+        window.history.replaceState({}, '', fullNewUrl);
+      } else {
+        window.history.pushState({}, '', fullNewUrl);
+      }
+
+      this.fire('location-changed', {}, {node: window});
+    },
 
     /**
-     * @param {string} path
-     * @param {string=} base
-     * @return {!URL|!HTMLAnchorElement}
+     * A necessary evil so that links work as expected. Does its best to
+     * bail out early if possible.
+     *
+     * @param {MouseEvent} event .
      */
-    function resolveURL(path, base) {
-      if (workingURL === undefined) {
-        workingURL = false;
-        try {
-          var u = new URL('b', 'http://a');
-          u.pathname = 'c%20d';
-          workingURL = (u.href === 'http://a/c%20d');
-          workingURL = workingURL && (new URL('http://www.google.com/?foo bar').href === 'http://www.google.com/?foo%20bar');
-        } catch (e) {}
+    _globalOnClick: function(event) {
+      // If another event handler has stopped this event then there's nothing
+      // for us to do. This can happen e.g. when there are multiple
+      // iron-location elements in a page.
+      if (event.defaultPrevented) {
+        return;
       }
-      if (workingURL) {
-        return new URL(path, base);
+
+      var href = this._getSameOriginLinkHref(event);
+
+      if (!href) {
+        return;
       }
-      if (!urlDoc) {
-        urlDoc = document.implementation.createHTMLDocument('url');
-        urlBase = urlDoc.createElement('base');
-        urlDoc.head.appendChild(urlBase);
-        anchor = /** @type {HTMLAnchorElement}*/(urlDoc.createElement('a'));
+
+      event.preventDefault();
+
+      // If the navigation is to the current page we shouldn't add a history
+      // entry or fire a change event.
+      if (href === this.__location.href) {
+        return;
       }
-      urlBase.href = base;
-      anchor.href = path.replace(/ /g, '%20');
-      return anchor;
+
+      window.history.pushState({}, '', href);
+      this.fire('location-changed', {}, {node: window});
+    },
+
+    /**
+     * Returns the absolute URL of the link (if any) that this click event
+     * is clicking on, if we can and should override the resulting full
+     * page navigation. Returns null otherwise.
+     *
+     * @param {MouseEvent} event .
+     * @return {string?} .
+     */
+    _getSameOriginLinkHref: function(event) {
+      // We only care about left-clicks.
+      if (event.button !== 0) {
+        return null;
+      }
+
+      // We don't want modified clicks, where the intent is to open the page
+      // in a new tab.
+      if (event.metaKey || event.ctrlKey) {
+        return null;
+      }
+
+      var eventPath = Polymer.dom(event).path;
+      var anchor = null;
+
+      for (var i = 0; i < eventPath.length; i++) {
+        var element = eventPath[i];
+
+        if (element.tagName === 'A' && element.href) {
+          anchor = element;
+          break;
+        }
+      }
+
+      // If there's no link there's nothing to do.
+      if (!anchor) {
+        return null;
+      }
+
+      // Target blank is a new tab, don't intercept.
+      if (anchor.target === '_blank') {
+        return null;
+      }
+
+      // If the link is for an existing parent frame, don't intercept.
+      if ((anchor.target === '_top' || anchor.target === '_parent') &&
+          window.top !== window) {
+        return null;
+      }
+
+      // If the link is a download, don't intercept.
+      if (anchor.download) {
+        return null;
+      }
+
+      var href = anchor.href;
+
+      // It only makes sense for us to intercept same-origin navigations.
+      // pushState/replaceState don't work with cross-origin links.
+      var url;
+
+      if (document.baseURI != null) {
+        url = resolveURL(href, /** @type {string} */ (document.baseURI));
+      } else {
+        url = resolveURL(href);
+      }
+
+      var origin;
+
+      // IE Polyfill
+      if (this.__location.origin) {
+        origin = this.__location.origin;
+      } else {
+        origin = this.__location.protocol + '//' + this.__location.host;
+      }
+
+      var urlOrigin;
+
+      if (url.origin) {
+        urlOrigin = url.origin;
+      } else {
+        // IE always adds port number on HTTP and HTTPS on <a>.host but not on
+        // window.location.host
+        var urlHost = url.host;
+        var urlPort = url.port;
+        var urlProtocol = url.protocol;
+        var isExtraneousHTTPS = urlProtocol === 'https:' && urlPort === '443';
+        var isExtraneousHTTP = urlProtocol === 'http:' && urlPort === '80';
+
+        if (isExtraneousHTTPS || isExtraneousHTTP) {
+          urlHost = url.hostname;
+        }
+        urlOrigin = urlProtocol + '//' + urlHost;
+      }
+
+      if (urlOrigin !== origin) {
+        return null;
+      }
+
+      var normalizedHref = url.pathname + url.search + url.hash;
+
+      // pathname should start with '/', but may not if `new URL` is not supported
+      if (normalizedHref[0] !== '/') {
+        normalizedHref = '/' + normalizedHref;
+      }
+
+      // If we've been configured not to handle this url... don't handle it!
+      if (this._urlSpaceRegExp && !this._urlSpaceRegExp.test(normalizedHref)) {
+        return null;
+      }
+
+      // Need to use a full URL in case the containing page has a base URI.
+      var fullNormalizedHref =
+          resolveURL(normalizedHref, this.__location.href).href;
+      return fullNormalizedHref;
+    },
+
+    _makeRegExp: function(urlSpaceRegex) {
+      return RegExp(urlSpaceRegex);
     }
-
-    Polymer({
-      is: 'iron-location',
-
-      properties: {
-        /**
-         * The pathname component of the URL.
-         */
-        path: {
-          type: String,
-          notify: true,
-          value: function() {
-            return window.decodeURIComponent(window.location.pathname);
-          }
-        },
-
-        /**
-         * The query string portion of the URL.
-         */
-        query: {
-          type: String,
-          notify: true,
-          value: function() {
-            return window.location.search.slice(1);
-          }
-        },
-
-        /**
-         * The hash component of the URL.
-         */
-        hash: {
-          type: String,
-          notify: true,
-          value: function() {
-            return window.decodeURIComponent(window.location.hash.slice(1));
-          }
-        },
-
-        /**
-         * If the user was on a URL for less than `dwellTime` milliseconds, it
-         * won't be added to the browser's history, but instead will be replaced
-         * by the next entry.
-         *
-         * This is to prevent large numbers of entries from clogging up the user's
-         * browser history. Disable by setting to a negative number.
-         */
-        dwellTime: {
-          type: Number,
-          value: 2000
-        },
-
-        /**
-         * A regexp that defines the set of URLs that should be considered part
-         * of this web app.
-         *
-         * Clicking on a link that matches this regex won't result in a full page
-         * navigation, but will instead just update the URL state in place.
-         *
-         * This regexp is given everything after the origin in an absolute
-         * URL. So to match just URLs that start with /search/ do:
-         *     url-space-regex="^/search/"
-         *
-         * @type {string|RegExp}
-         */
-        urlSpaceRegex: {
-          type: String,
-          value: ''
-        },
-
-        /**
-         * A flag that specifies whether the spaces in query that would normally be encoded as %20 should be
-         * encoded as +.
-         *
-         * Given an example text "hello world", it is encoded in query as
-         * - "hello%20world" without the parameter
-         * - "hello+world" with the parameter
-         */
-        encodeSpaceAsPlusInQuery: {
-          type: Boolean,
-          value: false
-        },
-
-        /**
-         * urlSpaceRegex, but coerced into a regexp.
-         *
-         * @type {RegExp}
-         */
-        _urlSpaceRegExp: {
-          computed: '_makeRegExp(urlSpaceRegex)'
-        },
-
-        _lastChangedAt: {
-          type: Number
-        },
-
-        _initialized: {
-          type: Boolean,
-          value: false
-        }
-      },
-
-      hostAttributes: {
-        hidden: true
-      },
-
-      observers: [
-        '_updateUrl(path, query, hash)'
-      ],
-
-      created: function() {
-        this.__location = window.location;
-      },
-
-      attached: function() {
-        this.listen(window, 'hashchange', '_hashChanged');
-        this.listen(window, 'location-changed', '_urlChanged');
-        this.listen(window, 'popstate', '_urlChanged');
-        this.listen(/** @type {!HTMLBodyElement} */(document.body), 'click', '_globalOnClick');
-        // Give a 200ms grace period to make initial redirects without any
-        // additions to the user's history.
-        this._lastChangedAt = window.performance.now() - (this.dwellTime - 200);
-        this._initialized = true;
-
-        this._urlChanged();
-      },
-
-      detached: function() {
-        this.unlisten(window, 'hashchange', '_hashChanged');
-        this.unlisten(window, 'location-changed', '_urlChanged');
-        this.unlisten(window, 'popstate', '_urlChanged');
-        this.unlisten(/** @type {!HTMLBodyElement} */(document.body), 'click', '_globalOnClick');
-        this._initialized = false;
-      },
-
-      _hashChanged: function() {
-        this.hash = window.decodeURIComponent(this.__location.hash.substring(1));
-      },
-
-      _urlChanged: function() {
-        // We want to extract all info out of the updated URL before we
-        // try to write anything back into it.
-        //
-        // i.e. without _dontUpdateUrl we'd overwrite the new path with the old
-        // one when we set this.hash. Likewise for query.
-        this._dontUpdateUrl = true;
-        this._hashChanged();
-        this.path = window.decodeURIComponent(this.__location.pathname);
-        this.query = this.__location.search.substring(1);
-        this._dontUpdateUrl = false;
-        this._updateUrl();
-      },
-
-      _getUrl: function() {
-        var partiallyEncodedPath = window.encodeURI(
-            this.path).replace(/\#/g, '%23').replace(/\?/g, '%3F');
-        var partiallyEncodedQuery = '';
-        if (this.query) {
-          partiallyEncodedQuery = '?' + this.query.replace(/\#/g, '%23');
-          if(this.encodeSpaceAsPlusInQuery) {
-            partiallyEncodedQuery = partiallyEncodedQuery.replace(/\+/g, '%2B').replace(/ /g, '+').replace(/%20/g, '+');
-          }
-        }
-        var partiallyEncodedHash = '';
-        if (this.hash) {
-          partiallyEncodedHash = '#' + window.encodeURI(this.hash);
-        }
-        return (
-            partiallyEncodedPath + partiallyEncodedQuery + partiallyEncodedHash);
-      },
-
-      _updateUrl: function() {
-        if (this._dontUpdateUrl || !this._initialized) {
-          return;
-        }
-
-        if (this.path === window.decodeURIComponent(this.__location.pathname) &&
-            this.query === this.__location.search.substring(1) &&
-            this.hash === window.decodeURIComponent(
-                this.__location.hash.substring(1))) {
-          // Nothing to do, the current URL is a representation of our properties.
-          return;
-        }
-
-        var newUrl = this._getUrl();
-        // Need to use a full URL in case the containing page has a base URI.
-        var fullNewUrl = resolveURL(newUrl, this.__location.protocol + '//' + this.__location.host).href;
-        var now = window.performance.now();
-        var shouldReplace = this._lastChangedAt + this.dwellTime > now;
-        this._lastChangedAt = now;
-
-        if (shouldReplace) {
-          window.history.replaceState({}, '', fullNewUrl);
-        } else {
-          window.history.pushState({}, '', fullNewUrl);
-        }
-
-        this.fire('location-changed', {}, {node: window});
-      },
-
-      /**
-       * A necessary evil so that links work as expected. Does its best to
-       * bail out early if possible.
-       *
-       * @param {MouseEvent} event .
-       */
-      _globalOnClick: function(event) {
-        // If another event handler has stopped this event then there's nothing
-        // for us to do. This can happen e.g. when there are multiple
-        // iron-location elements in a page.
-        if (event.defaultPrevented) {
-          return;
-        }
-
-        var href = this._getSameOriginLinkHref(event);
-
-        if (!href) {
-          return;
-        }
-
-        event.preventDefault();
-
-        // If the navigation is to the current page we shouldn't add a history
-        // entry or fire a change event.
-        if (href === this.__location.href) {
-          return;
-        }
-
-        window.history.pushState({}, '', href);
-        this.fire('location-changed', {}, {node: window});
-      },
-
-      /**
-       * Returns the absolute URL of the link (if any) that this click event
-       * is clicking on, if we can and should override the resulting full
-       * page navigation. Returns null otherwise.
-       *
-       * @param {MouseEvent} event .
-       * @return {string?} .
-       */
-      _getSameOriginLinkHref: function(event) {
-        // We only care about left-clicks.
-        if (event.button !== 0) {
-          return null;
-        }
-
-        // We don't want modified clicks, where the intent is to open the page
-        // in a new tab.
-        if (event.metaKey || event.ctrlKey) {
-          return null;
-        }
-
-        var eventPath = Polymer.dom(event).path;
-        var anchor = null;
-
-        for (var i = 0; i < eventPath.length; i++) {
-          var element = eventPath[i];
-
-          if (element.tagName === 'A' && element.href) {
-            anchor = element;
-            break;
-          }
-        }
-
-        // If there's no link there's nothing to do.
-        if (!anchor) {
-          return null;
-        }
-
-        // Target blank is a new tab, don't intercept.
-        if (anchor.target === '_blank') {
-          return null;
-        }
-
-        // If the link is for an existing parent frame, don't intercept.
-        if ((anchor.target === '_top' ||
-            anchor.target === '_parent') &&
-            window.top !== window) {
-          return null;
-        }
-        
-        // If the link is a download, don't intercept.
-        if (anchor.download) {
-          return null;
-        }
-
-        var href = anchor.href;
-
-        // It only makes sense for us to intercept same-origin navigations.
-        // pushState/replaceState don't work with cross-origin links.
-        var url;
-
-        if (document.baseURI != null) {
-          url = resolveURL(href, /** @type {string} */(document.baseURI));
-        } else {
-          url = resolveURL(href);
-        }
-
-        var origin;
-
-        // IE Polyfill
-        if (this.__location.origin) {
-          origin = this.__location.origin;
-        } else {
-          origin = this.__location.protocol + '//' + this.__location.host;
-        }
-
-        var urlOrigin;
-
-        if (url.origin) {
-          urlOrigin = url.origin;
-        } else {
-          // IE always adds port number on HTTP and HTTPS on <a>.host but not on
-          // window.location.host
-          var urlHost = url.host;
-          var urlPort = url.port;
-          var urlProtocol = url.protocol;
-          var isExtraneousHTTPS = urlProtocol === 'https:' && urlPort === '443';
-          var isExtraneousHTTP = urlProtocol === 'http:' && urlPort === '80';
-
-          if (isExtraneousHTTPS || isExtraneousHTTP) {
-            urlHost = url.hostname;
-          }
-          urlOrigin = urlProtocol + '//' + urlHost;
-        }
-
-        if (urlOrigin !== origin) {
-          return null;
-        }
-
-        var normalizedHref = url.pathname + url.search + url.hash;
-
-        // pathname should start with '/', but may not if `new URL` is not supported
-        if (normalizedHref[0] !== '/') {
-          normalizedHref = '/' + normalizedHref;
-        }
-
-        // If we've been configured not to handle this url... don't handle it!
-        if (this._urlSpaceRegExp &&
-            !this._urlSpaceRegExp.test(normalizedHref)) {
-          return null;
-        }
-
-        // Need to use a full URL in case the containing page has a base URI.
-        var fullNormalizedHref = resolveURL(
-            normalizedHref, this.__location.href).href;
-        return fullNormalizedHref;
-      },
-
-      _makeRegExp: function(urlSpaceRegex) {
-        return RegExp(urlSpaceRegex);
-      }
-    });
+  });
   })();
 </script>

--- a/iron-query-params.html
+++ b/iron-query-params.html
@@ -32,19 +32,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       },
 
-      _dontReact: {
-        type: Boolean,
-        value: false
-      }
+      _dontReact: {type: Boolean, value: false}
     },
 
-    hostAttributes: {
-      hidden: true
-    },
+    hostAttributes: {hidden: true},
 
-    observers: [
-      'paramsObjectChanged(paramsObject.*)'
-    ],
+    observers: ['paramsObjectChanged(paramsObject.*)'],
 
     paramsStringChanged: function() {
       this._dontReact = true;
@@ -57,7 +50,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return;
       }
       this.paramsString = this._encodeParams(this.paramsObject)
-          .replace(/%3F/g, '?').replace(/%2F/g, '/').replace(/'/g, '%27');
+                              .replace(/%3F/g, '?')
+                              .replace(/%2F/g, '/')
+                              .replace(/'/g, '%27');
     },
 
     _encodeParams: function(params) {
@@ -71,10 +66,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         } else if (value) {
           encodedParams.push(
-              encodeURIComponent(key) +
-              '=' +
-              encodeURIComponent(value.toString())
-          );
+              encodeURIComponent(key) + '=' +
+              encodeURIComponent(value.toString()));
         }
       }
       return encodedParams.join('&');

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,23 +3,34 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
+      }
+    },
     "@polymer/gen-typescript-declarations": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-1.2.0.tgz",
-      "integrity": "sha512-a5DFXI3TdZSVOMH4608LVaBLmcr+mwM2+B8OSBiB9WFNCtdqzUXwtB5We6vBzrThXlO4uRo7d2pEqjNXMAlEkA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-1.2.2.tgz",
+      "integrity": "sha512-9P946+nIkSm+761v3oxH/QVgJozhsInldKY3h8AVstdXkA8W0Fij84pqsFv1nrRuPGj4Pv71crzoZpFnLkNmKQ==",
       "dev": true,
       "requires": {
         "@types/doctrine": "0.0.3",
-        "@types/fs-extra": "5.0.0",
+        "@types/fs-extra": "5.0.1",
         "@types/glob": "5.0.35",
         "command-line-args": "5.0.2",
-        "command-line-usage": "4.1.0",
+        "command-line-usage": "5.0.4",
         "doctrine": "2.1.0",
-        "escodegen": "1.9.0",
+        "escodegen": "1.9.1",
         "fs-extra": "5.0.0",
         "glob": "7.1.2",
         "minimatch": "3.0.4",
-        "polymer-analyzer": "3.0.0-pre.12"
+        "polymer-analyzer": "3.0.0-pre.14",
+        "vscode-uri": "1.0.3"
       }
     },
     "@types/babel-generator": {
@@ -95,18 +106,18 @@
       "dev": true
     },
     "@types/events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
-      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-qtxDULQKUenuaDLW003CgC+0T0eiAfH3BrH+vSt87GLzbz5EZ6Ox6mv9rMttvhDOatbb9nYh0E1m7ydoYwUrAg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
+      "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.3"
       }
     },
     "@types/glob": {
@@ -115,10 +126,16 @@
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/events": "1.1.0",
+        "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.3"
       }
+    },
+    "@types/is-windows": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -127,9 +144,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.4.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.3.tgz",
+      "integrity": "sha512-igaEysRgtg5tYJVIdQ1T2lJ3G6OmoY7g0YVWKHLFiVs4YUChd9IRSiLoHSLffwut+CpsHHBDj4vRxxNEMstctw==",
       "dev": true
     },
     "@types/parse5": {
@@ -138,25 +155,25 @@
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.3"
+      }
+    },
+    "@types/resolve": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+      "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.6.3"
       }
     },
     "@types/winston": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.8.tgz",
-      "integrity": "sha512-QqR0j08RCS1AQYPMRPHikEpcmK+2aEEbcSzWLwOqyJ4FhLmHUx/WjRrnn7tTQg/y4IKnMhzskh/o7qvGIZZ7iA==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.9.tgz",
+      "integrity": "sha512-zzruYOEtNgfS3SBjcij1F6HlH6My5n8WrBNhP3fzaRM22ba70QBC2ATs18jGr88Fy43c0z8vFJv5wJankfxv2A==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
-      }
-    },
-    "ansi-escape-sequences": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
-      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0"
+        "@types/node": "9.6.3"
       }
     },
     "ansi-regex": {
@@ -166,10 +183,13 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.1"
+      }
     },
     "argv-tools": {
       "version": "0.1.1",
@@ -181,6 +201,24 @@
         "find-replace": "2.0.1"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
     "array-back": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
@@ -190,19 +228,37 @@
         "typical": "2.6.1"
       }
     },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
     "async": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
       "dev": true
     },
+    "atob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+      "dev": true
+    },
     "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
+      "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "chalk": "2.3.2",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
       }
@@ -221,6 +277,47 @@
         "lodash": "4.17.5",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.5",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
+      "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "7.0.0-beta.3",
+        "babel-template": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
+      "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
+      "dev": true,
+      "requires": {
+        "babel-types": "7.0.0-beta.3"
       }
     },
     "babel-messages": {
@@ -238,43 +335,78 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.5",
         "regenerator-runtime": "0.11.1"
       }
     },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+    "babel-template": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.3.tgz",
+      "integrity": "sha512-urJduLja89kSDGqY8ryw8iIwQnMl30IvhMtMNmDD7vBX0l0oylaLgK+7df/9ODX9vR/PhXuif6HYl5HlzAKXMg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
         "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.27",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
+      "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-helper-function-name": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
+        "debug": "3.1.0",
+        "globals": "10.4.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.27",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+          "dev": true
+        }
       }
     },
     "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+      "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
         "lodash": "4.17.5",
-        "to-fast-properties": "1.0.3"
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
       }
     },
     "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
       "dev": true
     },
     "balanced-match": {
@@ -283,10 +415,65 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
     "bower": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
-      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc=",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz",
+      "integrity": "sha1-54dqB23rgTf30GUl3F6MZtuC8oo=",
       "dev": true
     },
     "brace-expansion": {
@@ -299,23 +486,157 @@
         "concat-map": "0.0.1"
       }
     },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
+    "cancel-token": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
+      "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
+      "dev": true,
+      "requires": {
+        "@types/node": "4.2.23"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "4.2.23",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
+          "integrity": "sha512-U6IchCNLRyswc9p6G6lxWlbE+KwAhZp6mGo6MD2yWpmFomhYmetK+c98OpKyvphNn04CU3aXeJrXdOqbXVTS/w==",
+          "dev": true
+        }
+      }
+    },
+    "chalk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "5.3.0"
+      }
+    },
+    "clang-format": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.2.3.tgz",
+      "integrity": "sha512-x90Hac4ERacGDcZSvHKK58Ga0STuMD+Doi5g0iG2zf7wlJef5Huvhs/3BvMRFxwRYyYSdl6mpQNrtfMxE8MQzw==",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "glob": "7.1.2",
+        "resolve": "1.7.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
       }
     },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -338,16 +659,22 @@
       }
     },
     "command-line-usage": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-      "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-h17lBwC5bl5RdukPbXji75+cg2/Qbny6kGsmLoy34s9DNH90RwRvJKb+VU5j4YY9HzYl7twLaOWDJQ4b9U+p/Q==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "4.0.0",
         "array-back": "2.0.0",
-        "table-layout": "0.4.2",
+        "chalk": "2.3.2",
+        "table-layout": "0.4.3",
         "typical": "2.6.1"
       }
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -355,10 +682,16 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
       "dev": true
     },
     "cssbeautify": {
@@ -374,13 +707,19 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.5.0",
@@ -393,6 +732,47 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -419,7 +799,7 @@
       "dev": true,
       "requires": {
         "@types/parse5": "2.2.34",
-        "clone": "2.1.1",
+        "clone": "2.1.2",
         "parse5": "4.0.0"
       }
     },
@@ -430,16 +810,16 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "requires": {
         "esprima": "3.1.3",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
       }
     },
     "esprima": {
@@ -460,17 +840,183 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
     "eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
+    "fast-glob": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.0.tgz",
+      "integrity": "sha512-4F75PTznkNtSKs2pbhtBwRkw8sRwa7LfXx5XaQJOe4IQ6yTjceLDTwM5gj1s80R2t/5WeDC1gVfm3jLE+l39Tw==",
+      "dev": true,
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.1",
+        "micromatch": "3.1.10"
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
     },
     "find-replace": {
       "version": "2.0.1",
@@ -480,6 +1026,21 @@
       "requires": {
         "array-back": "2.0.0",
         "test-value": "3.0.0"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "0.2.2"
       }
     },
     "fs-extra": {
@@ -499,6 +1060,12 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -513,10 +1080,37 @@
         "path-is-absolute": "1.0.1"
       }
     },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        }
+      }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+      "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
       "dev": true
     },
     "graceful-fs": {
@@ -532,6 +1126,44 @@
       "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "indent": {
@@ -557,13 +1189,90 @@
       "dev": true
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -573,6 +1282,79 @@
       "requires": {
         "number-is-nan": "1.0.1"
       }
+    },
+    "is-glob": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-odd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -602,9 +1384,15 @@
       }
     },
     "jsonschema": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
-      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
     "levn": {
@@ -635,6 +1423,12 @@
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -642,6 +1436,48 @@
       "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
+    "merge2": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
+      "integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.9",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "minimatch": {
@@ -662,17 +1498,107 @@
         "minimatch": "3.0.4"
       }
     },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "nanomatch": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -703,10 +1629,34 @@
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "plylog": {
@@ -716,8 +1666,8 @@
       "dev": true,
       "requires": {
         "@types/node": "4.2.23",
-        "@types/winston": "2.3.8",
-        "winston": "2.4.0"
+        "@types/winston": "2.3.9",
+        "winston": "2.4.1"
       },
       "dependencies": {
         "@types/node": {
@@ -729,9 +1679,9 @@
       }
     },
     "polymer-analyzer": {
-      "version": "3.0.0-pre.12",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.12.tgz",
-      "integrity": "sha512-QQL70IC85hI6q9uQeresEMcT1Qf8YR/zDe1qG8WWeeFAZk8z0lmzUpsfcAWz+bM4wpDdXrtd4HitIs4p0CHl/w==",
+      "version": "3.0.0-pre.14",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.14.tgz",
+      "integrity": "sha512-1Zh/smUWMrjBB7NFUk8i7EAnjO81PqhI0/RzMMy9VgAbPQ6jOROwFX71T02CgpkZYa0O66Ybl7G3+4+0S1aF1Q==",
       "dev": true,
       "requires": {
         "@types/babel-generator": "6.25.1",
@@ -743,27 +1693,34 @@
         "@types/clone": "0.1.30",
         "@types/cssbeautify": "0.3.1",
         "@types/doctrine": "0.0.1",
+        "@types/is-windows": "0.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "6.0.101",
+        "@types/node": "6.0.105",
         "@types/parse5": "2.2.34",
+        "@types/resolve": "0.0.6",
         "babel-generator": "6.26.1",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.44",
+        "cancel-token": "0.1.1",
         "chalk": "1.1.3",
-        "clone": "2.1.1",
+        "clone": "2.1.2",
         "cssbeautify": "0.3.1",
         "doctrine": "2.1.0",
         "dom5": "3.0.0",
         "indent": "0.0.2",
-        "jsonschema": "1.2.2",
+        "is-windows": "1.0.2",
+        "jsonschema": "1.2.4",
         "minimatch": "3.0.4",
         "parse5": "4.0.0",
-        "polymer-project-config": "3.8.1",
+        "path-is-inside": "1.0.2",
+        "polymer-project-config": "3.13.0",
+        "resolve": "1.7.0",
         "shady-css-parser": "0.1.0",
         "stable": "0.1.6",
         "strip-indent": "2.0.0",
-        "vscode-uri": "1.0.1"
+        "vscode-uri": "1.0.3",
+        "whatwg-url": "6.4.0"
       },
       "dependencies": {
         "@types/doctrine": {
@@ -773,37 +1730,74 @@
           "dev": true
         },
         "@types/node": {
-          "version": "6.0.101",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+          "version": "6.0.105",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.105.tgz",
+          "integrity": "sha512-fMIbw7iw91TSInS3b2DtDse5VaQEZqs0oTjvRNIFHnoHbnji+dLwpzL1L6dYGL39RzDNPHM/Off+VNcMk4ahwQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "polymer-project-config": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.8.1.tgz",
-      "integrity": "sha512-MLvnM9gexFWg7nynY24eHZG6NLXocmk718sVds/sx2CAJ6iihhC0JMhhOIa6jnad9KQrHyGl/cs3mMRaaub5Fg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.13.0.tgz",
+      "integrity": "sha512-0E1iSOpo2xFMvMomSDFl48J8IOUWmM+sfHGJSQSVfIu8GXDgz2TVraad+rEMZDbj8uxiRFvQZyouHhikxhVFpQ==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.101",
-        "jsonschema": "1.2.2",
+        "@types/node": "6.0.105",
+        "jsonschema": "1.2.4",
         "minimatch-all": "1.1.0",
         "plylog": "0.5.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.101",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+          "version": "6.0.105",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.105.tgz",
+          "integrity": "sha512-fMIbw7iw91TSInS3b2DtDse5VaQEZqs0oTjvRNIFHnoHbnji+dLwpzL1L6dYGL39RzDNPHM/Off+VNcMk4ahwQ==",
           "dev": true
         }
       }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
       "dev": true
     },
     "reduce-flatten": {
@@ -818,6 +1812,28 @@
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
@@ -827,17 +1843,221 @@
         "is-finite": "1.0.2"
       }
     },
+    "resolve": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
+      "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "0.1.15"
+      }
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
     "shady-css-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
       "integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA==",
       "dev": true
     },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "dev": true,
+      "requires": {
+        "atob": "2.1.0",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2"
+      }
     },
     "stable": {
       "version": "0.1.6",
@@ -850,6 +2070,27 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -867,15 +2108,18 @@
       "dev": true
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+      "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
+      }
     },
     "table-layout": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
-      "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.3.tgz",
+      "integrity": "sha512-MIhflPM38ejKrFwWwC3P9x3eHvMo5G5AmNo29Qtz2HpBl5KD2GCcmOErjgNtUQLv/qaqVDagfJY3rJLPDvEgLg==",
       "dev": true,
       "requires": {
         "array-back": "2.0.0",
@@ -901,6 +2145,57 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      }
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -922,22 +2217,141 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
     },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
       "dev": true
     },
-    "vscode-uri": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
-      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g=",
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "use": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      }
+    },
+    "vscode-uri": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
+      "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI=",
+      "dev": true
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "webmat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/webmat/-/webmat-0.2.0.tgz",
+      "integrity": "sha512-xf2iHrssbbTofFwxvrdtgSxILQ8ledlpeDc76fNkTEL76gGnxCB/YA69UF498+UPfYIDvVnk9Qt2E7MJOApacA==",
+      "dev": true,
+      "requires": {
+        "clang-format": "1.2.3",
+        "dom5": "3.0.0",
+        "fast-glob": "2.2.0",
+        "parse5": "4.0.0"
+      }
+    },
+    "whatwg-url": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
+      }
+    },
     "winston": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
-      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
+      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
       "dev": true,
       "requires": {
         "async": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
       "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.3"
+        "@types/node": "8.10.7"
       }
     },
     "@types/glob": {
@@ -128,7 +128,7 @@
       "requires": {
         "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.6.3"
+        "@types/node": "8.10.7"
       }
     },
     "@types/is-windows": {
@@ -144,9 +144,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.3.tgz",
-      "integrity": "sha512-igaEysRgtg5tYJVIdQ1T2lJ3G6OmoY7g0YVWKHLFiVs4YUChd9IRSiLoHSLffwut+CpsHHBDj4vRxxNEMstctw==",
+      "version": "8.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.7.tgz",
+      "integrity": "sha512-5QC0YAHH7aXzrrbgQ+faSeBKbJwTaUyYuaywYzDTr1Myz5C0knx5FHOV5QyhBeE1x8n2xfkBUGE/C0X1paLp+Q==",
       "dev": true
     },
     "@types/parse5": {
@@ -155,7 +155,7 @@
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.3"
+        "@types/node": "8.10.7"
       }
     },
     "@types/resolve": {
@@ -164,7 +164,7 @@
       "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.3"
+        "@types/node": "8.10.7"
       }
     },
     "@types/winston": {
@@ -173,7 +173,7 @@
       "integrity": "sha512-zzruYOEtNgfS3SBjcij1F6HlH6My5n8WrBNhP3fzaRM22ba70QBC2ATs18jGr88Fy43c0z8vFJv5wJankfxv2A==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.3"
+        "@types/node": "8.10.7"
       }
     },
     "ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   "license": "BSD-3-Clause",
   "devDependencies": {
     "@polymer/gen-typescript-declarations": "^1.2.0",
-    "bower": "^1.8.0"
+    "bower": "^1.8.0",
+    "webmat": "^0.2.0"
   },
   "scripts": {
-    "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir ."
+    "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir .",
+    "format": "webmat && npm run update-types"
   }
 }

--- a/test/initialization-cases.html
+++ b/test/initialization-cases.html
@@ -13,24 +13,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
   Polymer({
     is: 'default-value',
-    properties: {
-      value: {
-        type: String,
-        notify: true,
-        value: 'default-value'
-      }
-    },
+    properties: {value: {type: String, notify: true, value: 'default-value'}},
   });
 
   Polymer({
     is: 'on-attached',
-    properties: {
-      val: {
-        type: String,
-        notify: true,
-        value: 'on-attached-default-value'
-      }
-    },
+    properties:
+        {val: {type: String, notify: true, value: 'on-attached-default-value'}},
     attached: function() {
       if (this.val === 'on-attached-default-value') {
         this.val = 'on-attached';
@@ -40,13 +29,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer({
     is: 'on-ready',
-    properties: {
-      val: {
-        type: String,
-        notify: true,
-        value: 'on-ready-default-value'
-      }
-    },
+    properties:
+        {val: {type: String, notify: true, value: 'on-ready-default-value'}},
 
     ready: function() {
       this.val = 'on-ready';
@@ -55,13 +39,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer({
     is: 'on-timeout',
-    properties: {
-      val: {
-        type: String,
-        notify: true,
-        value: 'on-timeout-default-value'
-      }
-    },
+    properties:
+        {val: {type: String, notify: true, value: 'on-timeout-default-value'}},
     attached: function() {
       setTimeout(function() {
         this.val = 'on-timeout';
@@ -76,7 +55,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <iron-location query='{{val}}'></iron-location>
 
   </template>
-  <script>Polymer({is: 'default-before', properties: {val: {type: String}}});</script>
+  <script>
+    Polymer({is: 'default-before', properties: {val: {type: String}}});
+  </script>
 </dom-module>
 
 <dom-module id='attached-before'>
@@ -84,7 +65,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <on-attached val='{{val}}'></on-attached>
     <iron-location query='{{val}}'></iron-location>
   </template>
-  <script>Polymer({is: 'attached-before', properties: {val: {type: String}}});</script>
+  <script>
+    Polymer({is: 'attached-before', properties: {val: {type: String}}});
+  </script>
 </dom-module>
 
 <dom-module id="ready-before">
@@ -93,12 +76,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <iron-location query="{{val}}"></iron-location>
   </template>
   <script>
-    Polymer({
-      is: 'ready-before',
-      properties: {
-        val: String
-      }
-    });
+    Polymer({is: 'ready-before', properties: {val: String}});
   </script>
 </dom-module>
 
@@ -107,7 +85,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <on-timeout val='{{val}}'></on-timeout>
     <iron-location query='{{val}}'></iron-location>
   </template>
-  <script>Polymer({is: 'timeout-before', properties: {val: {type: String}}});</script>
+  <script>
+    Polymer({is: 'timeout-before', properties: {val: {type: String}}});
+  </script>
 </dom-module>
 
 
@@ -116,7 +96,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <iron-location query='{{val}}'></iron-location>
     <default-value value='{{val}}'></default-value>
   </template>
-  <script>Polymer({is: 'default-after', properties: {val: {type: String}}});</script>
+  <script>
+    Polymer({is: 'default-after', properties: {val: {type: String}}});
+  </script>
 </dom-module>
 
 <dom-module id='attached-after'>
@@ -124,7 +106,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <iron-location query='{{val}}'></iron-location>
     <on-attached val='{{val}}'></on-attached>
   </template>
-  <script>Polymer({is: 'attached-after', properties: {val: {type: String}}});</script>
+  <script>
+    Polymer({is: 'attached-after', properties: {val: {type: String}}});
+  </script>
 </dom-module>
 
 <dom-module id="ready-after">
@@ -133,12 +117,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <on-ready val="{{val}}"></on-ready>
   </template>
   <script>
-    Polymer({
-      is: 'ready-after',
-      properties: {
-        val: String
-      }
-    });
+    Polymer({is: 'ready-after', properties: {val: String}});
   </script>
 </dom-module>
 
@@ -147,7 +126,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <iron-location query='{{val}}'></iron-location>
     <on-timeout val='{{val}}'></on-timeout>
   </template>
-  <script>Polymer({is: 'timeout-after', properties: {val: {type: String}}});</script>
+  <script>
+    Polymer({is: 'timeout-after', properties: {val: {type: String}}});
+  </script>
 </dom-module>
 
 <dom-module id='default-below'>
@@ -156,7 +137,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <default-value value='{{val}}'></default-value>
     </iron-location>
   </template>
-  <script>Polymer({is: 'default-below', properties: {val: {type: String}}});</script>
+  <script>
+    Polymer({is: 'default-below', properties: {val: {type: String}}});
+  </script>
 </dom-module>
 
 <dom-module id='attached-below'>
@@ -165,7 +148,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <on-attached val='{{val}}'></on-attached>
     </iron-location>
   </template>
-  <script>Polymer({is: 'attached-below', properties: {val: {type: String}}});</script>
+  <script>
+    Polymer({is: 'attached-below', properties: {val: {type: String}}});
+  </script>
 </dom-module>
 
 <dom-module id="ready-below">
@@ -175,12 +160,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </iron-location>
   </template>
   <script>
-    Polymer({
-      is: 'ready-below',
-      properties: {
-        val: String
-      }
-    });
+    Polymer({is: 'ready-below', properties: {val: String}});
   </script>
 </dom-module>
 
@@ -190,7 +170,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <on-timeout val='{{val}}'></on-timeout>
     </iron-location>
   </template>
-  <script>Polymer({is: 'timeout-below', properties: {val: {type: String}}});</script>
+  <script>
+    Polymer({is: 'timeout-below', properties: {val: {type: String}}});
+  </script>
 </dom-module>
 
 
@@ -200,7 +182,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <iron-location query='{{val}}'></iron-location>
     </default-value>
   </template>
-  <script>Polymer({is: 'default-above', properties: {val: {type: String}}});</script>
+  <script>
+    Polymer({is: 'default-above', properties: {val: {type: String}}});
+  </script>
 </dom-module>
 
 <dom-module id='attached-above'>
@@ -210,7 +194,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </iron-location>
     </on-attached>
   </template>
-  <script>Polymer({is: 'attached-above', properties: {val: {type: String}}});</script>
+  <script>
+    Polymer({is: 'attached-above', properties: {val: {type: String}}});
+  </script>
 </dom-module>
 
 <dom-module id="ready-above">
@@ -220,12 +206,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </on-ready>
   </template>
   <script>
-    Polymer({
-      is: 'ready-above',
-      properties: {
-        val: String
-      }
-    });
+    Polymer({is: 'ready-above', properties: {val: String}});
   </script>
 </dom-module>
 
@@ -235,7 +216,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <iron-location query='{{val}}'></iron-location>
     </on-timeout>
   </template>
-  <script>Polymer({is: 'timeout-above', properties: {val: {type: String}}});</script>
+  <script>
+    Polymer({is: 'timeout-above', properties: {val: {type: String}}});
+  </script>
 </dom-module>
 
 
@@ -275,9 +258,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     Polymer({
       is: 'ready-above',
-      properties: {
-        val: String
-      },
+      properties: {val: String},
       ready: function() {
         this.val = 'ready-container-val';
       }
@@ -289,18 +270,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template>
     <iron-location query='{{val}}'></iron-location>
   </template>
-  <script>Polymer({
-    is: 'timeout-container',
-    properties: {
-      val: {
-        type: String,
-        notify: true
+  <script>
+    Polymer({
+      is: 'timeout-container',
+      properties: {val: {type: String, notify: true}},
+      attached: function() {
+        setTimeout(function() {
+          this.val = 'on-timeout';
+        }.bind(this), 10);
       }
-    },
-    attached: function() {
-      setTimeout(function() {
-        this.val = 'on-timeout';
-      }.bind(this), 10);
-    }
-  });</script>
+    });
+  </script>
 </dom-module>

--- a/test/initialization-iframe.html
+++ b/test/initialization-iframe.html
@@ -18,12 +18,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </head>
   <body>
     <script>
-      window.addEventListener("message", messageReceived, false);
+      window.addEventListener('message', messageReceived, false);
 
       window.addEventListener('WebComponentsReady', function() {
-        window.parent.postMessage({
-          'type': 'ready'
-        }, '*');
+        window.parent.postMessage({'type': 'ready'}, '*');
       });
 
       var appendBodyReceived = false;
@@ -33,13 +31,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
         // the parent can (at any time) ask for our URL.
         if (msg.data.type === 'urlQuery') {
-          msg.source.postMessage({
-            'type': 'urlQueryResponse',
-            'href': window.location.href,
-            'pathname': window.location.pathname,
-            'hash': window.location.hash,
-            'search': window.location.search
-          }, '*');
+          msg.source.postMessage(
+              {
+                'type': 'urlQueryResponse',
+                'href': window.location.href,
+                'pathname': window.location.pathname,
+                'hash': window.location.hash,
+                'search': window.location.search
+              },
+              '*');
         } else if (msg.data.type === 'appendBody') {
           if (appendBodyReceived) {
             throw new Error('should only receive at most one appendBody call');
@@ -51,10 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       window.addEventListener('error', function(e) {
-        window.parent.postMessage({
-          'type': 'error',
-          'error': e.message
-        }, '*');
+        window.parent.postMessage({'type': 'error', 'error': e.message}, '*');
       });
     </script>
   </body>

--- a/test/initialization-tests.html
+++ b/test/initialization-tests.html
@@ -40,36 +40,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     'use strict';
 
-    window.addEventListener('WebComponentsReady', function () {
+    window.addEventListener('WebComponentsReady', function() {
       function getIframe() {
-        return new Promise(function (resolve, reject) {
+        return new Promise(function(resolve, reject) {
           var iframe = document.createElement('iframe');
-          var result = getMessageMatching(iframe, function (message) {
+          var result = getMessageMatching(iframe, function(message) {
             return message.type === 'ready';
           });
           iframe.src = './initialization-iframe.html';
           document.body.appendChild(iframe);
           iframe.addEventListener('error', reject);
-          result.then(function () { resolve(iframe) }, reject);
+          result.then(function() {
+            resolve(iframe)
+          }, reject);
         });
       }
 
       function onMessage(iframe, callback) {
-        var f = function (event) {
+        var f = function(event) {
           if (event.source === iframe.contentWindow) {
             callback(event.data);
           }
         };
         window.addEventListener('message', f, false);
-        return function () {
+        return function() {
           window.removeEventListener('message', f);
         }
       }
 
       function getMessageMatching(iframe, predicate) {
-        var revoke = function () { };
-        var result = new Promise(function (resolve, reject) {
-          revoke = onMessage(iframe, function (message) {
+        var revoke = function() {};
+        var result = new Promise(function(resolve, reject) {
+          revoke = onMessage(iframe, function(message) {
             if (predicate(message)) {
               resolve(message);
             }
@@ -80,43 +82,47 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       function getUrl(iframe) {
-        var result = getMessageMatching(iframe, function (message) {
+        var result = getMessageMatching(iframe, function(message) {
           return message.type === 'urlQueryResponse';
         })
-        var revoke = function () { };
-        result.then(function () {
-          return new Promise(function (resolve, reject) {
+        var revoke = function() {};
+        result.then(function() {
+          return new Promise(function(resolve, reject) {
             revoke = onMessage(iframe, resolve);
           });
         });
         result.then(revoke, revoke);
-        iframe.contentWindow.postMessage({ type: 'urlQuery' }, '*');
+        iframe.contentWindow.postMessage({type: 'urlQuery'}, '*');
         return result;
       }
 
       function timePasses(ms) {
-        return new Promise(function (resolve) {
-          window.setTimeout(function () {
+        return new Promise(function(resolve) {
+          window.setTimeout(function() {
             resolve();
           }, ms);
         });
       }
 
-      suite('<iron-location>\'s initialization', function () {
+      suite('<iron-location>\'s initialization', function() {
         var iframe;
         var error;
-        setup(function () {
-          return getIframe().then(function (i) {
-            iframe = i;
-            function isError(m) { return m.type === 'error' }
-            getMessageMatching(iframe, isError).then(function (m) {
-              error = m.error;
-            });
-          }.bind(this)).then(function () {
-            return cooldownFunction.call(this);
-          }.bind(this));
+        setup(function() {
+          return getIframe()
+              .then(function(i) {
+                iframe = i;
+                function isError(m) {
+                  return m.type === 'error'
+                }
+                getMessageMatching(iframe, isError).then(function(m) {
+                  error = m.error;
+                });
+              }.bind(this))
+              .then(function() {
+                return cooldownFunction.call(this);
+              }.bind(this));
         });
-        teardown(function () {
+        teardown(function() {
           if (iframe) {
             document.body.removeChild(iframe);
           }
@@ -129,35 +135,61 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return cooldownFunction.call(this);
         });
         var cases = [
-          'default-before', 'attached-before', 'ready-before',
+          'default-before',
+          'attached-before',
+          'ready-before',
           // TODO: These tests are failing with Polymer 2 (#95).
           // 'default-after', 'attached-after', 'ready-after',
           // 'default-below', 'attached-below', 'ready-below',
-          'default-above', 'attached-above', 'ready-above',
-          'default-container', 'attached-container', 'ready-container'
+          'default-above',
+          'attached-above',
+          'ready-above',
+          'default-container',
+          'attached-container',
+          'ready-container'
         ];
-        cases.forEach(function (caseName) {
-          test('the url takes priority in ' + caseName + ' initialization', function () {
-            return getUrl(iframe).then(function (url) {
-              expect(url.search).to.be.eq('');
-              iframe.contentWindow.postMessage({ type: 'appendBody', tagName: caseName }, '*');
-              return timePasses(60).then(function () { return getUrl(iframe) });
-            }).then(function (url) {
-              expect(url.search).to.be.eq('');
-            });
-          });
+        cases.forEach(function(caseName) {
+          test(
+              'the url takes priority in ' + caseName + ' initialization',
+              function() {
+                return getUrl(iframe)
+                    .then(function(url) {
+                      expect(url.search).to.be.eq('');
+                      iframe.contentWindow.postMessage(
+                          {type: 'appendBody', tagName: caseName}, '*');
+                      return timePasses(60).then(function() {
+                        return getUrl(iframe)
+                      });
+                    })
+                    .then(function(url) {
+                      expect(url.search).to.be.eq('');
+                    });
+              });
         });
-        var expectedFailureCases = ['timeout-before', 'timeout-after', 'timeout-below', 'timeout-above', 'timeout-container'];
-        expectedFailureCases.forEach(function (caseName) {
-          test('the url does not take priority in ' + caseName + ' initialization', function () {
-            return getUrl(iframe).then(function (url) {
-              expect(url.search).to.be.eq('');
-              iframe.contentWindow.postMessage({ type: 'appendBody', tagName: caseName }, '*');
-              return timePasses(60).then(function () { return getUrl(iframe) });
-            }).then(function (url) {
-              expect(url.search).to.be.eq('?on-timeout');
-            });
-          });
+        var expectedFailureCases = [
+          'timeout-before',
+          'timeout-after',
+          'timeout-below',
+          'timeout-above',
+          'timeout-container'
+        ];
+        expectedFailureCases.forEach(function(caseName) {
+          test(
+              'the url does not take priority in ' + caseName + ' initialization',
+              function() {
+                return getUrl(iframe)
+                    .then(function(url) {
+                      expect(url.search).to.be.eq('');
+                      iframe.contentWindow.postMessage(
+                          {type: 'appendBody', tagName: caseName}, '*');
+                      return timePasses(60).then(function() {
+                        return getUrl(iframe)
+                      });
+                    })
+                    .then(function(url) {
+                      expect(url.search).to.be.eq('?on-timeout');
+                    });
+              });
         });
       });
     });

--- a/test/integration.html
+++ b/test/integration.html
@@ -43,10 +43,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </iron-query-params>
     </template>
     <script>
-      HTMLImports.whenReady(function () {
-        Polymer({
-          is: 'integration-element'
-        });
+      HTMLImports.whenReady(function() {
+        Polymer({is: 'integration-element'});
       });
     </script>
   </dom-module>
@@ -60,13 +58,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     'use strict';
 
-    window.addEventListener('WebComponentsReady', function () {
-      suite('Integration tests', function () {
+    window.addEventListener('WebComponentsReady', function() {
+      suite('Integration tests', function() {
         var integration;
         var ironLocation;
         var ironQueryParams;
 
-        setup(function () {
+        setup(function() {
           integration = fixture('Integration');
           ironLocation = integration.$.location;
           ironQueryParams = integration.$.queryParams;
@@ -74,11 +72,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return cooldownFunction.call(this);
         });
 
-        teardown(function () {
+        teardown(function() {
           return cooldownFunction.call(this);
         });
 
-        test('propagations from location to iqp', function () {
+        test('propagations from location to iqp', function() {
           var queryEncodingExamples = {
             'foo': '?foo',
             '': '',
@@ -95,7 +93,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               encodedQueries = [encodedQueries];
               ironLocationQuery = [ironLocationQuery.substring(1)];
             } else {
-              ironLocationQuery = ironLocationQuery.map(function (value) {
+              ironLocationQuery = ironLocationQuery.map(function(value) {
                 return value.substring(1);
               });
             }
@@ -112,7 +110,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }
         });
 
-        test('propagations from iqp to location', function () {
+        test('propagations from iqp to location', function() {
           var queryEncodingExamples = {
             'foo': '?foo',
             '': '',
@@ -129,7 +127,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               encodedQueries = [encodedQueries];
               ironLocationQuery = [ironLocationQuery.substring(1)];
             } else {
-              ironLocationQuery = ironLocationQuery.map(function (value) {
+              ironLocationQuery = ironLocationQuery.map(function(value) {
                 return value.substring(1);
               });
             }

--- a/test/iron-location.html
+++ b/test/iron-location.html
@@ -459,7 +459,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                   var count = 0;
                   window.history.pushState = function() {
                     count++;
-                  } anchor.click();
+                  };
+                  anchor.click();
                   window.history.pushState = originalPushState;
 
                   expect(count).to.be.equal(0);

--- a/test/iron-location.html
+++ b/test/iron-location.html
@@ -79,10 +79,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     'use strict';
 
-    window.addEventListener('WebComponentsReady', function () {
+    window.addEventListener('WebComponentsReady', function() {
       function timePasses(ms) {
-        return new Promise(function (resolve) {
-          window.setTimeout(function () {
+        return new Promise(function(resolve) {
+          window.setTimeout(function() {
             resolve();
           }, ms);
         });
@@ -98,25 +98,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       /**
-      * We run the iron location tests with a couple different page configurations
-      * (e.g. with and without a base URI), so we define the test set as a function
-      * that we call in each of these configurations.
-      */
+       * We run the iron location tests with a couple different page configurations
+       * (e.g. with and without a base URI), so we define the test set as a function
+       * that we call in each of these configurations.
+       */
       function ironLocationTests() {
-        suite('when used solo', function () {
+        suite('when used solo', function() {
           var urlElem;
           var toRemove;
-          setup(function () {
+          setup(function() {
             replaceState('/');
             urlElem = fixture('Solo');
             toRemove = [];
           });
-          teardown(function () {
+          teardown(function() {
             for (var i = 0; i < toRemove.length; i++) {
               document.body.removeChild(toRemove[i]);
             }
           });
-          test('basic functionality with #hash urls', function () {
+          test('basic functionality with #hash urls', function() {
             // Initialized to the window location's hash.
             expect(window.location.hash).to.be.equal(urlElem.hash);
 
@@ -126,18 +126,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             // Changing the hash via normal means changes the urlElem.
             var anchor = document.createElement('a');
-            var base =
-              window.location.protocol + '//' + window.location.host +
-              window.location.pathname;
+            var base = window.location.protocol + '//' + window.location.host +
+                window.location.pathname;
             anchor.href = base + '#/wat';
             document.body.appendChild(anchor);
             anchor.click();
             // In IE10 it appears that the hashchange event is asynchronous.
-            return timePasses(10).then(function () {
+            return timePasses(10).then(function() {
               expect(urlElem.hash).to.be.equal('/wat');
             });
           });
-          test('basic functionality with paths', function () {
+          test('basic functionality with paths', function() {
             // Initialized to the window location's path.
             expect(window.location.pathname).to.be.equal(urlElem.path);
 
@@ -157,7 +156,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             toRemove.push(ironLocation);
             return ironLocation
           }
-          test('dealing with paths with unusual characters', function () {
+          test('dealing with paths with unusual characters', function() {
             var pathEncodingExamples = {
               '/foo': '/foo',
               '/': '/',
@@ -177,7 +176,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               expect(temporaryIronLocation.path).to.be.equal(plainTextPath);
             }
           });
-          test('dealing with hashes with unusual characters', function () {
+          test('dealing with hashes with unusual characters', function() {
             var hashEncodingExamples = {
               'foo': '#foo',
               '': '',
@@ -198,8 +197,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               expect(makeTemporaryIronLocation().hash).to.be.equal(plainTextHash);
             }
           });
-          suite('test special queries', function () {
-            setup(function (done) {
+          suite('test special queries', function() {
+            setup(function(done) {
               cooldownFunction.call(this, done, true);
             });
             function testQuery(queryEncodingExamples, encodeSpaceAsPlusInQuery) {
@@ -208,7 +207,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               for (var plainTextQuery in queryEncodingExamples) {
                 var encodedQueries = queryEncodingExamples[plainTextQuery];
 
-                var ironLocationQuery = encodedQueries.map(function (value) {
+                var ironLocationQuery = encodedQueries.map(function(value) {
                   return value.substring(1);
                 });
 
@@ -216,42 +215,50 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 urlElem.query = plainTextQuery;
                 expect(encodedQueries).to.contain(window.location.search);
                 expect(ironLocationQuery).to.contain(urlElem.query);
-                expect(ironLocationQuery).to.contain(makeTemporaryIronLocation().query);
+                expect(ironLocationQuery)
+                    .to.contain(makeTemporaryIronLocation().query);
 
                 urlElem.query = 'dummyValue';
                 urlElem.query = ironLocationQuery[0];
 
                 expect(encodedQueries).to.contain(window.location.search);
                 expect(ironLocationQuery).to.contain(urlElem.query);
-                expect(ironLocationQuery).to.contain(makeTemporaryIronLocation().query);
+                expect(ironLocationQuery)
+                    .to.contain(makeTemporaryIronLocation().query);
               }
             }
 
-            test('dealing with queries with unusual characters', function () {
-              testQuery({
-                'foo': ['?foo'],
-                '': [''],
-                'foo bar': ['?foo%20bar'],
-                'foo#bar': ['?foo%23bar'],
-                'foo?bar': ['?foo?bar'],
-                '/foo\'bar\'baz': ['?/foo%27bar%27baz', '?/foo\'bar\'baz'],
-                'foo/bar/baz': ['?foo/bar/baz']
-              }, false)
+            test('dealing with queries with unusual characters', function() {
+              testQuery(
+                  {
+                    'foo': ['?foo'],
+                    '': [''],
+                    'foo bar': ['?foo%20bar'],
+                    'foo#bar': ['?foo%23bar'],
+                    'foo?bar': ['?foo?bar'],
+                    '/foo\'bar\'baz': ['?/foo%27bar%27baz', '?/foo\'bar\'baz'],
+                    'foo/bar/baz': ['?foo/bar/baz']
+                  },
+                  false)
             });
-            test('dealing with queries with unusual characters - encodeSpaceAsPlusInQuery', function () {
-              testQuery({
-                '': [''],
-                'foo bar': ['?foo%20bar', '?foo+bar'],
-                'foo#bar': ['?foo%23bar'],
-                'foo+bar': ['?foo%2Bbar'],
-                'foo?bar': ['?foo?bar'],
-                '/foo\'bar\'baz': ['?/foo%27bar%27baz', '?/foo\'bar\'baz'],
-                'foo/bar/baz': ['?foo/bar/baz']
-              }, true)
-            });
+            test(
+                'dealing with queries with unusual characters - encodeSpaceAsPlusInQuery',
+                function() {
+                  testQuery(
+                      {
+                        '': [''],
+                        'foo bar': ['?foo%20bar', '?foo+bar'],
+                        'foo#bar': ['?foo%23bar'],
+                        'foo+bar': ['?foo%2Bbar'],
+                        'foo?bar': ['?foo?bar'],
+                        '/foo\'bar\'baz': ['?/foo%27bar%27baz', '?/foo\'bar\'baz'],
+                        'foo/bar/baz': ['?foo/bar/baz']
+                      },
+                      true)
+                });
           });
 
-          test('assigning to a relative path URL', function () {
+          test('assigning to a relative path URL', function() {
             urlElem.path = '/foo/bar';
             expect(window.location.pathname).to.be.equal('/foo/bar');
 
@@ -260,7 +267,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             urlElem.path = 'baz';
             expect(window.location.pathname).to.be.equal('/baz');
           });
-          test('basic functionality with ?key=value params', function () {
+          test('basic functionality with ?key=value params', function() {
             // Initialized to the window location's params.
             expect(urlElem.query).to.be.eq('');
 
@@ -272,48 +279,50 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             // Changing the urlElem's query changes the URL.
             urlElem.query = 'greeting=hello&target=world&another=key';
-            expect(window.location.search).to.be.equal(
-              '?greeting=hello&target=world&another=key');
+            expect(window.location.search)
+                .to.be.equal('?greeting=hello&target=world&another=key');
           });
         });
-        suite('does not spam the user\'s history', function () {
+        suite('does not spam the user\'s history', function() {
           var replaceStateCalls, pushStateCalls;
           var nativeReplaceState, nativePushState;
-          setup(function () {
+          setup(function() {
             replaceStateCalls = pushStateCalls = 0;
             nativeReplaceState = window.history.replaceState;
             nativePushState = window.history.pushState;
-            window.history.replaceState = function () {
+            window.history.replaceState = function() {
               replaceStateCalls++;
             };
-            window.history.pushState = function () {
+            window.history.pushState = function() {
               pushStateCalls++;
             };
           });
-          teardown(function () {
+          teardown(function() {
             window.history.replaceState = nativeReplaceState;
             window.history.pushState = nativePushState;
           });
-          test('when a change happens immediately after ' +
-            'the iron-location is attached', function () {
-              var ironLocation = fixture('Solo');
-              expect(pushStateCalls).to.be.equal(0);
-              expect(replaceStateCalls).to.be.equal(0);
-              ironLocation.path = '/foo';
-              expect(replaceStateCalls).to.be.equal(1);
-              expect(pushStateCalls).to.be.equal(0);
-            });
+          test(
+              'when a change happens immediately after ' +
+                  'the iron-location is attached',
+              function() {
+                var ironLocation = fixture('Solo');
+                expect(pushStateCalls).to.be.equal(0);
+                expect(replaceStateCalls).to.be.equal(0);
+                ironLocation.path = '/foo';
+                expect(replaceStateCalls).to.be.equal(1);
+                expect(pushStateCalls).to.be.equal(0);
+              });
 
-          suite('when intercepting links', function () {
+          suite('when intercepting links', function() {
             /**
-            * Clicks the given link while an iron-location element with the given
-            * urlSpaceRegex is in the same document. Returns whether the
-            * iron-location prevented the default behavior of the click.
-            *
-            * No matter what, it prevents the default behavior of the click itself
-            * to ensure that no navigation occurs (as that would interrupt
-            * running and reporting these tests!)
-            */
+             * Clicks the given link while an iron-location element with the given
+             * urlSpaceRegex is in the same document. Returns whether the
+             * iron-location prevented the default behavior of the click.
+             *
+             * No matter what, it prevents the default behavior of the click itself
+             * to ensure that no navigation occurs (as that would interrupt
+             * running and reporting these tests!)
+             */
             function isClickCaptured(anchor, urlSpaceRegex, location) {
               var defaultWasPrevented;
               function handler(event) {
@@ -339,7 +348,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               return defaultWasPrevented;
             }
 
-            test('simple link to / is intercepted', function () {
+            test('simple link to / is intercepted', function() {
               var anchor = document.createElement('a');
               if (document.baseURI !== window.location.href) {
                 anchor.href = makeAbsoluteUrl('/');
@@ -351,7 +360,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               expect(pushStateCalls).to.be.equal(1);
             });
 
-            test('test http port 80 intercepted', function () {
+            test('test http port 80 intercepted', function() {
               var anchor = document.createElement('a');
               anchor.href = 'http://www.example.com/hello/world'
 
@@ -369,7 +378,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               expect(pushStateCalls).to.be.equal(1);
             });
 
-            test('test https port 443 intercepted', function () {
+            test('test https port 443 intercepted', function() {
               var anchor = document.createElement('a');
               anchor.href = 'https://www.google.com/hello/world'
 
@@ -387,7 +396,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               expect(pushStateCalls).to.be.equal(1);
             });
 
-            test('link that matches url space is intercepted', function () {
+            test('link that matches url space is intercepted', function() {
               var anchor = document.createElement('a');
               anchor.href = makeAbsoluteUrl('/foo');
 
@@ -395,15 +404,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               expect(pushStateCalls).to.be.equal(1);
             });
 
-            test('link that doesn\'t match url space isn\'t intercepted', function () {
-              var anchor = document.createElement('a');
-              anchor.href = makeAbsoluteUrl('/bar');
+            test(
+                'link that doesn\'t match url space isn\'t intercepted',
+                function() {
+                  var anchor = document.createElement('a');
+                  anchor.href = makeAbsoluteUrl('/bar');
 
-              expect(isClickCaptured(anchor, '/fo+')).to.be.eq(false);
-              expect(pushStateCalls).to.be.equal(0);
-            });
+                  expect(isClickCaptured(anchor, '/fo+')).to.be.eq(false);
+                  expect(pushStateCalls).to.be.equal(0);
+                });
 
-            test('link to another domain isn\'t intercepted', function () {
+            test('link to another domain isn\'t intercepted', function() {
               var anchor = document.createElement('a');
               anchor.href = 'http://example.com/';
 
@@ -411,7 +422,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               expect(pushStateCalls).to.be.equal(0);
             });
 
-            test('a link with target=_blank isn\'t intercepted', function () {
+            test('a link with target=_blank isn\'t intercepted', function() {
               var anchor = document.createElement('a');
               anchor.href = makeAbsoluteUrl('/');
               anchor.target = '_blank';
@@ -420,42 +431,45 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               expect(pushStateCalls).to.be.equal(0);
             });
 
-            test('a link with an href to the ' +
-              'current page shouldn\'t add to history.', function () {
-                var anchor = document.createElement('a');
-                anchor.href = window.location.href;
+            test(
+                'a link with an href to the ' +
+                    'current page shouldn\'t add to history.',
+                function() {
+                  var anchor = document.createElement('a');
+                  anchor.href = window.location.href;
 
-                // The click is captured, but it doesn't add to history.
-                expect(isClickCaptured(anchor)).to.be.equal(true);
-                expect(pushStateCalls).to.be.equal(0);
-              });
-
-            test('a click that has already been defaultPrevented ' +
-              'shouldn\'t result in a navigation', function () {
-                fixture('Solo');
-                var anchor = document.createElement('a');
-                anchor.href = makeAbsoluteUrl('/');
-                anchor.addEventListener('click', function (event) {
-                  event.preventDefault();
+                  // The click is captured, but it doesn't add to history.
+                  expect(isClickCaptured(anchor)).to.be.equal(true);
+                  expect(pushStateCalls).to.be.equal(0);
                 });
-                document.body.appendChild(anchor);
 
-                var originalPushState = window.history.pushState;
-                var count = 0;
-                window.history.pushState = function () {
-                  count++;
-                }
-                anchor.click();
-                window.history.pushState = originalPushState;
+            test(
+                'a click that has already been defaultPrevented ' +
+                    'shouldn\'t result in a navigation',
+                function() {
+                  fixture('Solo');
+                  var anchor = document.createElement('a');
+                  anchor.href = makeAbsoluteUrl('/');
+                  anchor.addEventListener('click', function(event) {
+                    event.preventDefault();
+                  });
+                  document.body.appendChild(anchor);
 
-                expect(count).to.be.equal(0);
-              });
+                  var originalPushState = window.history.pushState;
+                  var count = 0;
+                  window.history.pushState = function() {
+                    count++;
+                  } anchor.click();
+                  window.history.pushState = originalPushState;
+
+                  expect(count).to.be.equal(0);
+                });
           });
         });
-        suite('when used with other iron-location elements', function () {
+        suite('when used with other iron-location elements', function() {
           var otherUrlElem;
           var urlElem;
-          setup(function () {
+          setup(function() {
             var elems = fixture('Together');
             urlElem = elems.querySelector('#one');
             otherUrlElem = elems.querySelector('#two');
@@ -465,7 +479,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(urlElemOne.hash).to.be.equal(urlElemTwo.hash);
             expect(urlElemOne.query).to.be.equal(urlElemTwo.query);
           }
-          test('coordinate their changes (by firing events on window)', function () {
+          test('coordinate their changes (by firing events on window)', function() {
             assertHaveSameUrls(urlElem, otherUrlElem);
 
             urlElem.path = '/a/b/c';
@@ -479,8 +493,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        suite('supports doing synchronous redirection', function () {
-          test('of the hash portion of the URL', function () {
+        suite('supports doing synchronous redirection', function() {
+          test('of the hash portion of the URL', function() {
             expect(window.location.hash).to.be.equal('');
             var redirector = fixture('RedirectHash');
             expect(window.location.hash).to.be.equal('#redirectedTo');
@@ -490,7 +504,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(redirector.hash).to.be.equal('redirectedTo');
           });
 
-          test('of the path portion of the URL', function () {
+          test('of the path portion of the URL', function() {
             expect(window.location.pathname).to.not.be.equal('/redirectedTo');
             var redirector = fixture('RedirectPath');
             expect(window.location.pathname).to.be.equal('/redirectedTo');
@@ -500,7 +514,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(redirector.path).to.be.equal('/redirectedTo');
           });
 
-          test('of the query portion of the URL', function () {
+          test('of the query portion of the URL', function() {
             expect(window.location.search).to.not.be.equal('?redirectedTo');
             var redirector = fixture('RedirectQuery');
             expect(window.location.search).to.be.equal('?redirectedTo');
@@ -512,24 +526,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       }
 
-      suite('<iron-location>', function () {
+      suite('<iron-location>', function() {
         var initialUrl;
-        setup(function () {
+        setup(function() {
           initialUrl = window.location.href;
           return cooldownFunction.call(this);
         });
-        teardown(function () {
+        teardown(function() {
           window.history.replaceState({}, '', initialUrl);
           return cooldownFunction.call(this);
         });
 
-        suite('without a base URI', function () {
+        suite('without a base URI', function() {
           ironLocationTests();
         });
 
-        suite('with a base URI', function () {
+        suite('with a base URI', function() {
           var baseElem;
-          setup(function () {
+          setup(function() {
             expect(document.baseURI).to.be.equal(window.location.href);
             baseElem = document.createElement('base');
             var href = 'https://example.com/i/dont/exist/obviously'
@@ -537,13 +551,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             document.head.appendChild(baseElem);
             expect(document.baseURI).to.be.equal(href);
           });
-          teardown(function () {
+          teardown(function() {
             document.head.removeChild(baseElem);
           });
           ironLocationTests();
         });
       });
     });
-
   </script>
 </body>

--- a/test/iron-query-params.html
+++ b/test/iron-query-params.html
@@ -42,55 +42,49 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     'use strict';
-    addEventListener('WebComponentsReady', function () {
-      suite('<iron-query-params>', function () {
-
+    addEventListener('WebComponentsReady', function() {
+      suite('<iron-query-params>', function() {
         var paramsElem;
-        setup(function () {
+        setup(function() {
           paramsElem = fixture('BasicQueryParams');
           return cooldownFunction.call(this);
         });
 
-        teardown(function () {
+        teardown(function() {
           return cooldownFunction.call(this);
         });
 
-        test('basic functionality with ?key=value params', function () {
+        test('basic functionality with ?key=value params', function() {
           // Check initialization
           expect(paramsElem.paramsString).to.be.eq('');
           expect(paramsElem.paramsObject).to.deep.eq({});
 
           // Check the mapping from paramsString to paramsObject.
           paramsElem.paramsString = 'greeting=hello&target=world';
-          expect(paramsElem.paramsObject).to.deep.equal(
-            { greeting: 'hello', target: 'world' });
+          expect(paramsElem.paramsObject)
+              .to.deep.equal({greeting: 'hello', target: 'world'});
 
           // Check the mapping from paramsObject back to paramsString.
           paramsElem.set('paramsObject.another', 'key');
-          expect(paramsElem.paramsString).to.be.equal(
-            'greeting=hello&target=world&another=key');
+          expect(paramsElem.paramsString)
+              .to.be.equal('greeting=hello&target=world&another=key');
         });
-        test('encoding of params', function () {
+        test('encoding of params', function() {
           var mappings = [
-            {
-              string: 'a=b',
-              object: { 'a': 'b' }
-            },
-            {
-              string: 'debug&ok',
-              object: { 'debug': '', 'ok': '' }
-            },
+            {string: 'a=b', object: {'a': 'b'}},
+            {string: 'debug&ok', object: {'debug': '', 'ok': ''}},
             {
               string: 'monster%20kid%3A=%F0%9F%98%BF&quotes=%27%27',
-              object: { 'monster kid:': '😿', 'quotes': '\'\'' }
+              object: {'monster kid:': '😿', 'quotes': '\'\''}
             },
             {
-              string: 'yes%2C%20ok?%20what%20is%20up%20with%20%CB%9Athiiis%CB%9A=%E2%98%83',
-              object: { 'yes, ok? what is up with ˚thiiis˚': '☃' }
+              string:
+                  'yes%2C%20ok?%20what%20is%20up%20with%20%CB%9Athiiis%CB%9A=%E2%98%83',
+              object: {'yes, ok? what is up with ˚thiiis˚': '☃'}
             },
           ];
 
-          mappings.forEach(function (mapping) {
+          mappings.forEach(function(mapping) {
             // Clear
             paramsElem.paramsObject = {};
             expect(paramsElem.paramsString).to.be.equal('');
@@ -108,11 +102,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(paramsElem.paramsString).to.be.equal(mapping.string);
           });
         });
-        test('query strings with alternative encodings', function () {
+        test('query strings with alternative encodings', function() {
           // Check the mapping for querystrings with + instead of %20.
           paramsElem.paramsString = 'key=value+with+spaces';
-          expect(paramsElem.paramsObject).to.deep.equal(
-            { key: 'value with spaces' });
+          expect(paramsElem.paramsObject).to.deep.equal({key: 'value with spaces'});
         });
       });
     });

--- a/test/redirection.html
+++ b/test/redirection.html
@@ -14,12 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     Polymer({
       is: 'redirect-hash',
-      properties: {
-        hash: {
-          value: '',
-          observer: 'hashChanged'
-        }
-      },
+      properties: {hash: {value: '', observer: 'hashChanged'}},
       hashChanged: function(hash) {
         this.hash = 'redirectedTo';
       }
@@ -34,12 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     Polymer({
       is: 'redirect-path',
-      properties: {
-        path: {
-          value: '',
-          observer: 'pathChanged'
-        }
-      },
+      properties: {path: {value: '', observer: 'pathChanged'}},
       pathChanged: function(path) {
         this.path = '/redirectedTo';
       }
@@ -54,12 +44,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     Polymer({
       is: 'redirect-query',
-      properties: {
-        query: {
-          value: '',
-          observer: 'queryChanged'
-        }
-      },
+      properties: {query: {value: '', observer: 'queryChanged'}},
       queryChanged: function(query) {
         this.query = 'redirectedTo';
       }

--- a/test/replace-state-patch.html
+++ b/test/replace-state-patch.html
@@ -1,81 +1,84 @@
 <script>
-  (function () {
-    function getRunnerWindow() {
-      var lastWindow;
-      var newWindow = window;
+  (function() {
+  function getRunnerWindow() {
+    var lastWindow;
+    var newWindow = window;
 
-      while (lastWindow != newWindow) {
-        lastWindow = newWindow;
-        newWindow = newWindow.parent;
+    while (lastWindow != newWindow) {
+      lastWindow = newWindow;
+      newWindow = newWindow.parent;
+    }
+
+    return newWindow;
+  };
+
+  var runnerWindow = getRunnerWindow();
+  /**
+   * Patches window.History.prototype.replaceState to count the number of times
+   * it has been called in `runnerWindow.replaceStateCount`
+   */
+  function patchReplaceState() {
+    if (typeof runnerWindow.replaceStateCount !== 'number') {
+      runnerWindow.replaceStateCount = 0;
+    }
+
+    var native = window.History.prototype.replaceState;
+
+    function patch() {
+      runnerWindow.replaceStateCount += 1;
+      return native.apply(window.history, arguments);
+    }
+
+    window.History.prototype.replaceState = patch;
+  }
+
+  window.cooldownFunction =
+      function(done) {
+    return new Promise(function(res) {
+      if (done) {
+        done();
+      };
+      res();
+    });
+  }
+
+  var isChrome =
+      /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
+  var isSafari = /^Apple/.test(navigator.vendor);
+
+  if (isChrome || isSafari) {
+    window.cooldownFunction = function(done, force) {
+      var resolve;
+      // this is for setups that return promises
+      var cooledDown = new Promise(function(res) {
+                         resolve = res;
+                       }).then(function() {
+        if (done) {
+          done();
+        }
+      });
+
+      if (runnerWindow.replaceStateCount > 85 || force) {
+        var cooldownPeriod = 30 * 1000;
+        this.timeout(cooldownPeriod + 5000);
+
+        var cooldownMessage = document.querySelector('#safari-cooldown');
+        cooldownMessage.removeAttribute('hidden');
+
+        setTimeout(function() {
+          cooldownMessage.setAttribute('hidden', 'hidden');
+          runnerWindow.replaceStateCount = 0;
+
+          resolve();
+        }, cooldownPeriod);
+      } else {
+        resolve();
       }
 
-      return newWindow;
+      return cooledDown;
     };
 
-    var runnerWindow = getRunnerWindow();
-    /**
-    * Patches window.History.prototype.replaceState to count the number of times
-    * it has been called in `runnerWindow.replaceStateCount`
-    */
-    function patchReplaceState() {
-      if (typeof runnerWindow.replaceStateCount !== 'number') {
-        runnerWindow.replaceStateCount = 0;
-      }
-
-      var native = window.History.prototype.replaceState;
-
-      function patch() {
-
-        runnerWindow.replaceStateCount += 1;
-        return native.apply(window.history, arguments);
-      }
-
-      window.History.prototype.replaceState = patch;
-    }
-
-    window.cooldownFunction = function (done) {
-      return new Promise(function (res) {
-        if (done) { done(); };
-        res();
-      });
-    }
-
-    var isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
-    var isSafari = /^Apple/.test(navigator.vendor);
-
-    if (isChrome || isSafari) {
-      window.cooldownFunction = function (done, force) {
-        var resolve;
-        // this is for setups that return promises
-        var cooledDown = new Promise(function (res) {
-          resolve = res;
-        }).then(function () {
-          if (done) {
-            done();
-          }
-        });
-
-        if (runnerWindow.replaceStateCount > 85 || force) {
-          var cooldownPeriod = 30 * 1000;
-          this.timeout(cooldownPeriod + 5000);
-
-          var cooldownMessage = document.querySelector('#safari-cooldown');
-          cooldownMessage.removeAttribute('hidden');
-
-          setTimeout(function () {
-            cooldownMessage.setAttribute('hidden', 'hidden');
-            runnerWindow.replaceStateCount = 0;
-
-            resolve();
-          }, cooldownPeriod);
-        } else {
-          resolve();
-        }
-
-        return cooledDown;
-      };
-
-      patchReplaceState();
-    }
+    patchReplaceState();
+  }
   })();
 </script>


### PR DESCRIPTION
Runs the experimental autoformatter [webmat](https://github.com/PolymerLabs/webmat) which runs clang-format on js files and makes it so that it can run on HTML files. Please look through this PR with `?w=1` in the diff to make sure that no logic was changed.

What has changed?
You can run the formatter on the whole project by running `npm run format` and ex/include files from the formatter, and enter your custom clang-format config in a formatconfig.json see webmat readme for more