### PR TITLE
Fix modulizer timeout

### DIFF
--- a/test/initialization-cases.html
+++ b/test/initialization-cases.html
@@ -257,7 +257,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
   <script>
     Polymer({
-      is: 'ready-above',
+      is: 'ready-container',
       properties: {val: String},
       ready: function() {
         this.val = 'ready-container-val';

--- a/test/initialization-tests.html
+++ b/test/initialization-tests.html
@@ -139,14 +139,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           'attached-before',
           'ready-before',
           // TODO: These tests are failing with Polymer 2 (#95).
-          // 'default-after', 'attached-after', 'ready-after',
-          // 'default-below', 'attached-below', 'ready-below',
+          // 'default-below',
+          // 'default-after',
+          // 'attached-below',
+          // 'attached-after',
+          // 'ready-below',
+          // 'ready-after',
+          // 'ready-container',
           'default-above',
           'attached-above',
           'ready-above',
           'default-container',
           'attached-container',
-          'ready-container'
         ];
         cases.forEach(function(caseName) {
           test(


### PR DESCRIPTION
Modulizer would timeout after I had an element defined twice. I fixed that and found that the test had always failed. This double definition happened in #54. oops.