### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/iron-location.js
+++ b/iron-location.js
@@ -53,6 +53,7 @@ milliseconds.
  */
 Polymer({
   is: 'iron-location',
+  _template: null,
 
   properties: {
     /**

--- a/iron-query-params.js
+++ b/iron-query-params.js
@@ -16,6 +16,7 @@ import {Polymer} from '@polymer/polymer/lib/legacy/polymer-fn.js';
  */
 Polymer({
   is: 'iron-query-params',
+  _template: null,
 
   properties: {
     /**


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336