### PR TITLE
When ignoring modified clicks, also ignore shift.

### DIFF
--- a/iron-location.js
+++ b/iron-location.js
@@ -292,7 +292,7 @@ Polymer({
 
     // We don't want modified clicks, where the intent is to open the page
     // in a new tab.
-    if (event.metaKey || event.ctrlKey) {
+    if (event.metaKey || event.ctrlKey || event.shiftKey) {
       return null;
     }
 


### PR DESCRIPTION
Shift-click opens in a new window.  This breaks it from working in polymer apps which use `<iron-location>`.